### PR TITLE
生データのブロードキャスト

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 NAME := ircserv
 
-SRCS := src/main.cpp src/IRCServer.cpp src/ClientSession.cpp
+SRCS := src/main.cpp src/IRCServer.cpp src/ClientSession.cpp \
+		src/CommandHandler.cpp src/IRCMessage.cpp
 OBJS := $(SRCS:.cpp=.o)
 CXXFLAGS += -I./include -Wall -Wextra -Werror -O0 -g -std=c++98 -pedantic-errors
 CXX := c++

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME := ircserv
 
 SRCS := src/main.cpp src/IRCServer.cpp src/ClientSession.cpp \
-		src/CommandHandler.cpp src/IRCMessage.cpp
+		src/CommandHandler.cpp src/IRCMessage.cpp src/Socket.cpp
 OBJS := $(SRCS:.cpp=.o)
 CXXFLAGS += -I./include -Wall -Wextra -Werror -O0 -g -std=c++98 -pedantic-errors
 CXX := c++

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NAME := ircserv
 SRCS := src/main.cpp src/IRCServer.cpp src/ClientSession.cpp \
 		src/CommandHandler.cpp src/IRCMessage.cpp src/Socket.cpp
 OBJS := $(SRCS:.cpp=.o)
-CXXFLAGS += -I./include -Wall -Wextra -Werror -O0 -g -std=c++98 -pedantic-errors
+CXXFLAGS += -I./include -Wall -Wextra -Werror -O0 -g -std=c++98 -pedantic-errors -DDEBUG
 CXX := c++
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME := ircserv
 
-SRCS := src/main.cpp
+SRCS := src/main.cpp src/IRCServer.cpp src/ClientSession.cpp
 OBJS := $(SRCS:.cpp=.o)
 CXXFLAGS += -I./include -Wall -Wextra -Werror -O0 -g -std=c++98 -pedantic-errors
 CXX := c++

--- a/include/ClientSession.hpp
+++ b/include/ClientSession.hpp
@@ -3,10 +3,11 @@
 #define __CLIENT_SESSION_HPP__
 
 #include <string>
+#include "Socket.hpp"
 
 class ClientSession {
  private:
-  int socketFd_;
+  Socket socket_;
   std::string nickName_;
   // std::string userName_;
   // std::string realName_;
@@ -21,7 +22,6 @@ class ClientSession {
   ClientSession(int socketFd);
   ~ClientSession();
 
-  // int getSocketFd() const;
   const std::string& getNickName() const;
   // void setNickName(const std::string& nick);
   // void setUserInfo(const std::string& user, const std::string& real);

--- a/include/ClientSession.hpp
+++ b/include/ClientSession.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#ifndef __CLIENT_SESSION_HPP__
+#define __CLIENT_SESSION_HPP__
+
+#include <string>
+
+class ClientSession {
+ private:
+  int socketFd_;
+  std::string nickName_;
+  // std::string userName_;
+  // std::string realName_;
+  // bool registered_; // NICKとUSER登録済みか
+  // std::set joinedChannels_;
+
+  ClientSession();
+  ClientSession(const ClientSession& other);
+  ClientSession& operator=(const ClientSession& other);
+
+ public:
+  ClientSession(int socketFd);
+  ~ClientSession();
+
+  int getSocketFd() const;
+  const std::string& getNickName() const;
+  // void setNickName(const std::string& nick);
+  // void setUserInfo(const std::string& user, const std::string& real);
+  // bool isRegistered() const;
+
+  // void joinChannel(Channel* channel);
+  // void partChannel(Channel* channel);
+  // const std::set& getChannels() const;
+};
+
+#endif  // __CLIENT_SESSION_HPP__

--- a/include/ClientSession.hpp
+++ b/include/ClientSession.hpp
@@ -22,6 +22,7 @@ class ClientSession {
   ClientSession(int socketFd);
   ~ClientSession();
 
+  int getFd() const;
   const std::string& getNickName() const;
   // void setNickName(const std::string& nick);
   // void setUserInfo(const std::string& user, const std::string& real);

--- a/include/ClientSession.hpp
+++ b/include/ClientSession.hpp
@@ -21,7 +21,7 @@ class ClientSession {
   ClientSession(int socketFd);
   ~ClientSession();
 
-  int getSocketFd() const;
+  // int getSocketFd() const;
   const std::string& getNickName() const;
   // void setNickName(const std::string& nick);
   // void setUserInfo(const std::string& user, const std::string& real);
@@ -30,6 +30,7 @@ class ClientSession {
   // void joinChannel(Channel* channel);
   // void partChannel(Channel* channel);
   // const std::set& getChannels() const;
+  void sendMessage(const std::string& message);
 };
 
 #endif  // __CLIENT_SESSION_HPP__

--- a/include/CommandHandler.hpp
+++ b/include/CommandHandler.hpp
@@ -19,6 +19,7 @@ class CommandHandler {
   // void handleQuit(ClientSession* client, const IRCMessage& message);
   // void handlePing(ClientSession* client, const IRCMessage& message);
   // void handlePong(ClientSession* client, const IRCMessage& message);
+  void broadCastRawMsg(const IRCMessage& msg);
 
  public:
   CommandHandler(IRCServer* server);

--- a/include/CommandHandler.hpp
+++ b/include/CommandHandler.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#ifndef __COMMAND_HANDLER_HPP__
+#define __COMMAND_HANDLER_HPP__
+
+#include <string>
+#include "IRCMessage.hpp"
+#include "IRCServer.hpp"
+
+class CommandHandler {
+ private:
+  IRCServer* server_;
+
+ private:
+  // void handleNick(ClientSession* client, const IRCMessage& message);
+  // void handleUser(ClientSession* client, const IRCMessage& message);
+  // void handleJoin(ClientSession* client, const IRCMessage& message);
+  // void handlePrivmsg(ClientSession* client, const IRCMessage& message);
+  // void handlePart(ClientSession* client, const IRCMessage& message);
+  // void handleQuit(ClientSession* client, const IRCMessage& message);
+  // void handlePing(ClientSession* client, const IRCMessage& message);
+  // void handlePong(ClientSession* client, const IRCMessage& message);
+
+ public:
+  CommandHandler(IRCServer* server);
+  ~CommandHandler();
+  CommandHandler(const CommandHandler& other);
+  CommandHandler& operator=(const CommandHandler& other);
+
+  void handleCommand(const IRCMessage& msg);
+};
+
+#endif  // __COMMAND_HANDLER_HPP__

--- a/include/IRCLogger.hpp
+++ b/include/IRCLogger.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#ifndef __IRC_LOGGER_HPP__
+#define __IRC_LOGGER_HPP__
+
+#include <iostream>
+
+#ifdef DEBUG
+#define DEBUG_MSG(msg)                          \
+  do {                                          \
+    std::cerr << "DEBUG: " << msg << std::endl; \
+  } while (0)
+#else
+#define DEBUG_MSG(msg) \
+  do {                 \
+  } while (0)
+#endif
+
+#endif  // __IRC_LOGGER_HPP__

--- a/include/IRCMessage.hpp
+++ b/include/IRCMessage.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#ifndef __IRC_MESSAGE_HPP__
+#define __IRC_MESSAGE_HPP__
+
+#include <string>
+#include "ClientSession.hpp"
+
+class IRCMessage {
+ private:
+  ClientSession* from_;
+  std::string raw_;
+  // std::string prefix_;
+  // std::string command_;
+  // std::vector params_;
+  IRCMessage();
+
+ public:
+  IRCMessage(ClientSession* from, const std::string& raw);
+  ~IRCMessage();
+  IRCMessage(const IRCMessage& other);
+  IRCMessage& operator=(const IRCMessage& other);
+
+  // bool parse(); // rawMessageを解析してprefix, command, paramsに分解
+  // std::string toString() const;  // メッセージの文字列化
+
+  const ClientSession* getFrom() const;
+  const std::string& getRaw() const;
+  // const std::string& getCommand() const;
+  // const std::vector& getParams() const;
+  // const std::string& getPrefix() const;
+};
+
+#endif  // __IRC_MESSAGE_HPP__

--- a/include/IRCMessage.hpp
+++ b/include/IRCMessage.hpp
@@ -28,6 +28,7 @@ class IRCMessage {
   // const std::string& getCommand() const;
   // const std::vector& getParams() const;
   // const std::string& getPrefix() const;
+  bool isFromMe(const ClientSession* client) const;
 };
 
 #endif  // __IRC_MESSAGE_HPP__

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -2,9 +2,10 @@
 #ifndef __IRC_SERVER_HPP__
 #define __IRC_SERVER_HPP__
 
+#include <map>
 #include <set>
 #include <string>
-// #include "ClientSession.hpp"
+#include "ClientSession.hpp"
 
 #define EPOLL_MAX_EVENTS 10
 
@@ -14,7 +15,7 @@ class IRCServer {
   std::string port_;
   std::string password_;
   std::set<int> listenSocketFds_;
-  // std::map<int, ClientSession*> clients_; // ソケットFD→クライアント
+  std::map<int, ClientSession*> clients_;  // ソケットFD→クライアント
   // UserManager userManager_;
   // ChannelManager channelManager_;
   // Logger logger_;
@@ -32,6 +33,9 @@ class IRCServer {
   // void receiveMessage(ClientSession* client);
   // void sendMessage(ClientSession* client, const std::string& message);
   // void disconnectClient(ClientSession* client);
+
+  // clients_を取得
+  std::map<int, ClientSession*>& getClients();
 };
 
 #endif  // __IRC_SERVER_HPP__

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#ifndef __IRC_SERVER_HPP__
+#define __IRC_SERVER_HPP__
+
+#include <string>
+#include <vector>
+// #include "ClientSession.hpp"
+
+class IRCServer {
+ private:
+  std::string port_;
+  std::string password_;
+  std::vector<int> listenSocketFds_;
+  // std::map<int, ClientSession*> clients_; // ソケットFD→クライアント
+  // UserManager userManager_;
+  // ChannelManager channelManager_;
+  // Logger logger_;
+
+ public:
+  IRCServer(const char* port, const char* password);
+  ~IRCServer();
+  IRCServer(const IRCServer& other);
+  IRCServer& operator=(const IRCServer& other);
+
+  void startListen();  // ソケットをバインドしてリッスン状態にする
+  void run();          // メインループ。接続受付、読み書き処理
+  // void acceptConnection();
+  // void receiveMessage(ClientSession* client);
+  // void sendMessage(ClientSession* client, const std::string& message);
+  // void disconnectClient(ClientSession* client);
+};
+
+#endif  // __IRC_SERVER_HPP__

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -2,19 +2,23 @@
 #ifndef __IRC_SERVER_HPP__
 #define __IRC_SERVER_HPP__
 
+#include <set>
 #include <string>
-#include <vector>
 // #include "ClientSession.hpp"
+
+#define EPOLL_MAX_EVENTS 10
 
 class IRCServer {
  private:
+  int epfd_;  // epollのファイルディスクリプタ
   std::string port_;
   std::string password_;
-  std::vector<int> listenSocketFds_;
+  std::set<int> listenSocketFds_;
   // std::map<int, ClientSession*> clients_; // ソケットFD→クライアント
   // UserManager userManager_;
   // ChannelManager channelManager_;
   // Logger logger_;
+  void acceptConnection(int listenSocketFd);
 
  public:
   IRCServer(const char* port, const char* password);

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -3,9 +3,9 @@
 #define __IRC_SERVER_HPP__
 
 #include <map>
-#include <set>
 #include <string>
 #include "ClientSession.hpp"
+#include "Socket.hpp"
 
 #define EPOLL_MAX_EVENTS 10
 
@@ -14,7 +14,7 @@ class IRCServer {
   int epfd_;  // epollのファイルディスクリプタ
   std::string port_;
   std::string password_;
-  std::set<int> listenSocketFds_;
+  std::map<int, Socket*> listenSockets_;   // ソケットFD→listeningソケット
   std::map<int, ClientSession*> clients_;  // ソケットFD→クライアント
   // UserManager userManager_;
   // ChannelManager channelManager_;

--- a/include/Socket.hpp
+++ b/include/Socket.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#ifndef __SOCKET_HPP__
+#define __SOCKET_HPP__
+
+class Socket {
+ private:
+  int fd_;
+
+  Socket();
+  Socket(const Socket& other);
+  Socket& operator=(const Socket& other);
+
+ public:
+  Socket(int socketFd);
+  ~Socket();
+
+  int getFd() const;
+};
+
+#endif  // __SOCKET_HPP__

--- a/src/ClientSession.cpp
+++ b/src/ClientSession.cpp
@@ -1,6 +1,7 @@
 
 
 #include "ClientSession.hpp"
+#include <sys/socket.h>
 #include <unistd.h>
 #include <iostream>
 
@@ -19,9 +20,9 @@ ClientSession::~ClientSession() {
   close(socketFd_);
 }
 
-int ClientSession::getSocketFd() const {
-  return socketFd_;
-}
+// int ClientSession::getSocketFd() const {
+//   return socketFd_;
+// }
 
 // ClientSession::ClientSession(const ClientSession& other) {
 //   *this = other;
@@ -35,3 +36,11 @@ int ClientSession::getSocketFd() const {
 //   nickName_ = other.nickName_;
 //   return *this;
 // }
+
+void ClientSession::sendMessage(const std::string& msg) {
+  if (send(socketFd_, msg.c_str(), msg.size(), 0) == -1) {
+    std::cerr << "send failed. fd: " << socketFd_ << ", nick: " << nickName_
+              << std::endl;
+    throw std::runtime_error("send failed");
+  }
+}

--- a/src/ClientSession.cpp
+++ b/src/ClientSession.cpp
@@ -1,0 +1,37 @@
+
+
+#include "ClientSession.hpp"
+#include <unistd.h>
+#include <iostream>
+
+ClientSession::ClientSession(int socketFd)
+    : socketFd_(socketFd), nickName_("") {
+  if (socketFd < 0) {
+    throw std::runtime_error("accept(2) failed");
+  }
+  std::cout << "ClientSession created fd: " << socketFd_ << std::endl;
+  socketFd_ = socketFd;
+}
+
+ClientSession::~ClientSession() {
+  std::cout << "ClientSession close fd: " << socketFd_
+            << ", nick: " << nickName_ << std::endl;
+  close(socketFd_);
+}
+
+int ClientSession::getSocketFd() const {
+  return socketFd_;
+}
+
+// ClientSession::ClientSession(const ClientSession& other) {
+//   *this = other;
+// }
+
+// ClientSession& ClientSession::operator=(const ClientSession& other) {
+//   if (this == &other) {
+//     return *this;
+//   }
+//   socketFd_ = other.socketFd_;
+//   nickName_ = other.nickName_;
+//   return *this;
+// }

--- a/src/ClientSession.cpp
+++ b/src/ClientSession.cpp
@@ -1,46 +1,16 @@
-
-
 #include "ClientSession.hpp"
 #include <sys/socket.h>
 #include <unistd.h>
 #include <iostream>
 
-ClientSession::ClientSession(int socketFd)
-    : socketFd_(socketFd), nickName_("") {
-  if (socketFd < 0) {
-    throw std::runtime_error("accept(2) failed");
-  }
-  std::cout << "ClientSession created fd: " << socketFd_ << std::endl;
-  socketFd_ = socketFd;
-}
+ClientSession::ClientSession(int socketFd) : socket_(socketFd), nickName_("") {}
 
-ClientSession::~ClientSession() {
-  std::cout << "ClientSession close fd: " << socketFd_
-            << ", nick: " << nickName_ << std::endl;
-  close(socketFd_);
-}
-
-// int ClientSession::getSocketFd() const {
-//   return socketFd_;
-// }
-
-// ClientSession::ClientSession(const ClientSession& other) {
-//   *this = other;
-// }
-
-// ClientSession& ClientSession::operator=(const ClientSession& other) {
-//   if (this == &other) {
-//     return *this;
-//   }
-//   socketFd_ = other.socketFd_;
-//   nickName_ = other.nickName_;
-//   return *this;
-// }
+ClientSession::~ClientSession() {}
 
 void ClientSession::sendMessage(const std::string& msg) {
-  if (send(socketFd_, msg.c_str(), msg.size(), 0) == -1) {
-    std::cerr << "send failed. fd: " << socketFd_ << ", nick: " << nickName_
-              << std::endl;
+  if (send(socket_.getFd(), msg.c_str(), msg.size(), 0) == -1) {
+    std::cerr << "send failed. fd: " << socket_.getFd()
+              << ", nick: " << nickName_ << std::endl;
     throw std::runtime_error("send failed");
   }
 }

--- a/src/ClientSession.cpp
+++ b/src/ClientSession.cpp
@@ -14,3 +14,7 @@ void ClientSession::sendMessage(const std::string& msg) {
     throw std::runtime_error("send failed");
   }
 }
+
+int ClientSession::getFd() const {
+  return socket_.getFd();
+}

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -1,5 +1,4 @@
 #include "CommandHandler.hpp"
-#include <sys/socket.h>
 
 CommandHandler::CommandHandler(IRCServer* server) : server_(server) {}
 CommandHandler::~CommandHandler() {}
@@ -26,8 +25,8 @@ void CommandHandler::handleCommand(const IRCMessage& msg) {
       // 自分自身はスキップ
       continue;
     } else {
-      // 受信したデータを他のクライアントに送信
-      send(it->first, msg.getRaw().c_str(), msg.getRaw().size(), 0);
+      // 受信したデータを他のクライアントにそのまま送信
+      it->second->sendMessage(msg.getRaw());
     }
   }
 }

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -16,10 +16,9 @@ CommandHandler& CommandHandler::operator=(const CommandHandler& other) {
 }
 
 void CommandHandler::broadCastRawMsg(const IRCMessage& msg) {
-  std::map<int, ClientSession*> clients = server_->getClients();
-
-  for (std::map<int, ClientSession*>::iterator it = clients.begin();
-       it != clients.end(); ++it) {
+  for (std::map<int, ClientSession*>::iterator it =
+           server_->getClients().begin();
+       it != server_->getClients().end(); ++it) {
     if (msg.isFromMe(it->second)) {
       // 自分自身はスキップ
       continue;
@@ -31,8 +30,6 @@ void CommandHandler::broadCastRawMsg(const IRCMessage& msg) {
 }
 
 void CommandHandler::handleCommand(const IRCMessage& msg) {
-  std::map<int, ClientSession*> clients = server_->getClients();
-
   DEBUG_MSG("CommandHandler::handleCommand from: "
             << msg.getFrom()->getFd() << std::endl
             << "----------------------" << std::endl

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -14,11 +14,9 @@ CommandHandler& CommandHandler::operator=(const CommandHandler& other) {
   return *this;
 }
 
-void CommandHandler::handleCommand(const IRCMessage& msg) {
+void CommandHandler::broadCastRawMsg(const IRCMessage& msg) {
   std::map<int, ClientSession*> clients = server_->getClients();
 
-  // TODO コマンドを解析して処理を分岐
-  // 受信したデータを他のクライアントにそのまま送信
   for (std::map<int, ClientSession*>::iterator it = clients.begin();
        it != clients.end(); ++it) {
     if (msg.isFromMe(it->second)) {
@@ -29,4 +27,12 @@ void CommandHandler::handleCommand(const IRCMessage& msg) {
       it->second->sendMessage(msg.getRaw());
     }
   }
+}
+
+void CommandHandler::handleCommand(const IRCMessage& msg) {
+  std::map<int, ClientSession*> clients = server_->getClients();
+
+  // TODO コマンドを解析して処理を分岐
+  // 受信したデータを他のクライアントにそのまま送信
+  broadCastRawMsg(msg);
 }

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -1,4 +1,5 @@
 #include "CommandHandler.hpp"
+#include "IRCLogger.hpp"
 
 CommandHandler::CommandHandler(IRCServer* server) : server_(server) {}
 CommandHandler::~CommandHandler() {}
@@ -31,6 +32,11 @@ void CommandHandler::broadCastRawMsg(const IRCMessage& msg) {
 
 void CommandHandler::handleCommand(const IRCMessage& msg) {
   std::map<int, ClientSession*> clients = server_->getClients();
+
+  DEBUG_MSG("CommandHandler::handleCommand from: "
+            << msg.getFrom()->getFd() << std::endl
+            << "----------------------" << std::endl
+            << msg.getRaw() << "----------------------");
 
   // TODO コマンドを解析して処理を分岐
   // 受信したデータを他のクライアントにそのまま送信

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -1,0 +1,33 @@
+#include "CommandHandler.hpp"
+#include <sys/socket.h>
+
+CommandHandler::CommandHandler(IRCServer* server) : server_(server) {}
+CommandHandler::~CommandHandler() {}
+CommandHandler::CommandHandler(const CommandHandler& other) {
+  *this = other;
+}
+
+CommandHandler& CommandHandler::operator=(const CommandHandler& other) {
+  if (this == &other) {
+    return *this;
+  }
+  server_ = other.server_;
+  return *this;
+}
+
+void CommandHandler::handleCommand(const IRCMessage& msg) {
+  std::map<int, ClientSession*> clients = server_->getClients();
+
+  // TODO コマンドを解析して処理を分岐
+  // 受信したデータを他のクライアントにそのまま送信
+  for (std::map<int, ClientSession*>::iterator it = clients.begin();
+       it != clients.end(); ++it) {
+    if (it->second == msg.getFrom()) {
+      // 自分自身はスキップ
+      continue;
+    } else {
+      // 受信したデータを他のクライアントに送信
+      send(it->first, msg.getRaw().c_str(), msg.getRaw().size(), 0);
+    }
+  }
+}

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -21,7 +21,7 @@ void CommandHandler::handleCommand(const IRCMessage& msg) {
   // 受信したデータを他のクライアントにそのまま送信
   for (std::map<int, ClientSession*>::iterator it = clients.begin();
        it != clients.end(); ++it) {
-    if (it->second == msg.getFrom()) {
+    if (msg.isFromMe(it->second)) {
       // 自分自身はスキップ
       continue;
     } else {

--- a/src/IRCMessage.cpp
+++ b/src/IRCMessage.cpp
@@ -1,0 +1,29 @@
+
+#include "IRCMessage.hpp"
+
+IRCMessage::IRCMessage(ClientSession* from, const std::string& raw)
+    : from_(from), raw_(raw) {}
+
+IRCMessage::~IRCMessage() {}
+
+IRCMessage::IRCMessage(const IRCMessage& other) {
+  *this = other;
+}
+
+IRCMessage& IRCMessage::operator=(const IRCMessage& other) {
+  if (this == &other) {
+    return *this;
+  }
+  from_ = other.from_;
+  raw_ = other.raw_;
+
+  return *this;
+}
+
+const ClientSession* IRCMessage::getFrom() const {
+  return from_;
+}
+
+const std::string& IRCMessage::getRaw() const {
+  return raw_;
+}

--- a/src/IRCMessage.cpp
+++ b/src/IRCMessage.cpp
@@ -27,3 +27,7 @@ const ClientSession* IRCMessage::getFrom() const {
 const std::string& IRCMessage::getRaw() const {
   return raw_;
 }
+
+bool IRCMessage::isFromMe(const ClientSession* client) const {
+  return from_ == client;
+}

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -1,0 +1,112 @@
+#include "IRCServer.hpp"
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include "ClientSession.hpp"
+
+#define MAX_BACKLOG 5
+
+IRCServer::IRCServer(const char* port, const char* password) {
+  // TODO: ポート番号のバリデーション
+  std::istringstream ss(port);
+  ss >> port_;
+
+  password_ = std::string(password);
+  std::cout << "Port: " << port_ << ", Password: " << password_ << std::endl;
+}
+
+IRCServer::~IRCServer() {
+  // ソケットを閉じる
+  for (size_t i = 0; i < listenSocketFds_.size(); ++i) {
+    std::cout << "Shutdown IRC Server: socket fd: " << listenSocketFds_[i]
+              << std::endl;
+    close(listenSocketFds_[i]);
+  }
+  listenSocketFds_.clear();
+  std::cout << "Server stopped." << std::endl;
+}
+
+IRCServer::IRCServer(const IRCServer& other) {
+  *this = other;
+}
+
+IRCServer& IRCServer::operator=(const IRCServer& other) {
+  if (this == &other) {
+    return *this;
+  }
+  port_ = other.port_;
+  password_ = other.password_;
+  return *this;
+}
+
+void IRCServer::startListen() {
+  struct addrinfo hints, *res, *ai;
+  memset(&hints, 0, sizeof(hints));
+  // TODO IPv6にも対応する必要あり
+  // hints.ai_family = AF_UNSPEC;  // IPv4 or IPv6
+  hints.ai_family = AF_INET;  // IPv4
+  // hints.ai_family = AF_INET6;  // IPv6
+  // netcatでIPv6で接続する方法
+  // nc -6 ::1 <port>
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_flags = AI_PASSIVE;  // 自分のIPアドレスを使用
+
+  int ret = getaddrinfo(NULL, port_.c_str(), &hints, &res);
+  if (ret != 0) {
+    std::cerr << "Error: getaddrinfo: " << gai_strerror(ret) << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  for (ai = res; ai != NULL; ai = ai->ai_next) {
+    int sockfd = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+    if (sockfd < 0)
+      continue;
+    // ソケット再利用
+    int yes = 1;
+    if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) < 0) {
+      std::cerr << "Error: setsockopt failed" << std::endl;
+      close(sockfd);
+      continue;
+    }
+    if (bind(sockfd, ai->ai_addr, ai->ai_addrlen) < 0) {
+      close(sockfd);
+      continue;
+    }
+    if (listen(sockfd, MAX_BACKLOG) < 0) {
+      close(sockfd);
+      continue;
+    }
+    std::cerr << "Listening on port: " << port_ << ", fd: " << sockfd << " ("
+              << ai->ai_family << ")..." << std::endl;
+    listenSocketFds_.push_back(sockfd);
+  }
+  freeaddrinfo(res);  // アドレス情報の解放
+  if (listenSocketFds_.empty()) {
+    std::cerr << "Error: socket/bind/listen failed" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+}
+
+void IRCServer::run() {
+  sockaddr_storage addr;
+  socklen_t addrlen = sizeof(addr);
+  std::cout << "------1" << std::endl;
+  int sockfd = accept(listenSocketFds_[0], (struct sockaddr*)&addr, &addrlen);
+  std::cout << "------2" << std::endl;
+  ClientSession client(sockfd);
+  // 日付を返す
+  time_t t;
+  time(&t);
+  char* timestr = ctime(&t);
+  // write(sockfd, timestr, strlen(timestr));
+  send(client.getSocketFd(), timestr, strlen(timestr), 0);
+}
+
+// void IRCServer::acceptConnection() {}

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -1,0 +1,21 @@
+#include "Socket.hpp"
+#include <unistd.h>
+#include <iostream>
+
+Socket::Socket(int fd) : fd_(fd) {
+  if (fd_ < 0) {
+    throw std::runtime_error("socket(2) failed");
+  }
+  std::cout << "Socket created fd: " << fd_ << std::endl;
+}
+
+Socket::~Socket() {
+  if (fd_ != -1) {
+    std::cout << "Socket closed fd: " << fd_ << std::endl;
+    close(fd_);
+  }
+}
+
+int Socket::getFd() const {
+  return fd_;
+}

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -11,8 +11,10 @@ Socket::Socket(int fd) : fd_(fd) {
 
 Socket::~Socket() {
   if (fd_ != -1) {
+    if (close(fd_) == -1) {
+      std::cerr << "close failed" << std::endl;
+    }
     std::cout << "Socket closed fd: " << fd_ << std::endl;
-    close(fd_);
   }
 }
 

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -1,12 +1,13 @@
 #include "Socket.hpp"
 #include <unistd.h>
 #include <iostream>
+#include "IRCLogger.hpp"
 
 Socket::Socket(int fd) : fd_(fd) {
   if (fd_ < 0) {
     throw std::runtime_error("socket(2) failed");
   }
-  std::cout << "Socket created fd: " << fd_ << std::endl;
+  DEBUG_MSG("Socket created fd: " << fd_);
 }
 
 Socket::~Socket() {
@@ -14,7 +15,7 @@ Socket::~Socket() {
     if (close(fd_) == -1) {
       std::cerr << "close failed" << std::endl;
     }
-    std::cout << "Socket closed fd: " << fd_ << std::endl;
+    DEBUG_MSG("Socket closed fd: " << fd_);
   }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,13 @@
 #include <iostream>
+#include "IRCServer.hpp"
 
-int main() {
-	std::cout << "Hello, IRC!" << std::endl;
-	return 0;
+int main(int argc, char* argv[]) {
+  if (argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " <port> <password>" << std::endl;
+    return 1;
+  }
+  IRCServer server(argv[1], argv[2]);
+  server.startListen();
+  server.run();
+  return 0;
 }

--- a/test/playground/syagi/03_io/epoll.cpp
+++ b/test/playground/syagi/03_io/epoll.cpp
@@ -1,0 +1,123 @@
+/*
+Usage
+
+Terminal 1:
+$ mkfifo p q
+$ ./a.out p q
+バックグラウンドへ(ctrl + z)
+
+Terminal 2:
+$ cat > p
+バックグラウンドへ(ctrl + z)
+$ cat > q
+hello
+world
+バックグラウンドへ(ctrl + z)
+$ fg %1
+12345
+67890
+
+Terminal 1:
+$ fg
+
+*/
+
+#include <fcntl.h>
+#include <sys/epoll.h>
+#include <unistd.h>
+#include <iostream>
+
+// Maximum bytes fetched by a single read()
+#define MAX_BUF 1024
+// #define MAX_BUF 3
+// Maximum number of events to be returned from a single epoll_wait() call
+#define MAX_EVENTS 5
+
+int main(int argc, char* argv[]) {
+  if (argc < 2) {
+    std::cout << "Usage: " << argv[0] << " file...\n";
+  }
+
+  int epfd = epoll_create(argc - 1);
+  if (epfd == -1) {
+    std::cerr << "epoll_create failed\n";
+    exit(EXIT_FAILURE);
+  }
+
+  for (int j = 1; j < argc; j++) {
+    int fd = open(argv[j], O_RDONLY);
+    if (fd == -1) {
+      std::cerr << "open failed\n" << argv[j] << std::endl;
+      exit(EXIT_FAILURE);
+    }
+    std::cout << "Opened \"" << argv[j] << "\" on fd " << fd << std::endl;
+
+    struct epoll_event ev;
+    ev.events = EPOLLIN; /* Only interested in input events */
+    ev.data.fd = fd;
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev) == -1) {
+      std::cerr << "epoll_ctl failed" << std::endl;
+    }
+  }
+
+  int numOpenFds = argc - 1;
+
+  while (numOpenFds > 0) {
+    /* Fetch up to MAX_EVENTS items from the ready list of the
+       epoll instance */
+
+    printf("About to epoll_wait()\n");
+
+    struct epoll_event evlist[MAX_EVENTS];
+
+    int ready = epoll_wait(epfd, evlist, MAX_EVENTS, -1);
+    if (ready == -1) {
+      if (errno == EINTR) {
+        continue; /* Restart if interrupted by signal */
+      } else {
+        std::cerr << "epoll_wait failed" << std::endl;
+      }
+    }
+
+    std::cout << "Ready: " << ready << std::endl;
+
+    /* Deal with returned list of events */
+    for (int j = 0; j < ready; j++) {
+      std::cout << "  fd=" << evlist[j].data.fd << "; events: "
+                << ((evlist[j].events & EPOLLIN) ? "EPOLLIN " : "")
+                << ((evlist[j].events & EPOLLHUP) ? "EPOLLHUP " : "")
+                << ((evlist[j].events & EPOLLERR) ? "EPOLLERR " : "")
+                << std::endl;
+
+      if (evlist[j].events & EPOLLIN) {
+        char buf[MAX_BUF];
+        int s = read(evlist[j].data.fd, buf, MAX_BUF);
+        if (s == -1) {
+          std::cerr << "read failed" << std::endl;
+          exit(EXIT_FAILURE);
+        }
+        std::cout << "    read " << s << " bytes: " << std::string(buf, s)
+                  << std::endl;
+
+      } else if (evlist[j].events & (EPOLLHUP | EPOLLERR)) {
+        /* After the epoll_wait(), EPOLLIN and EPOLLHUP may both have
+           been set. But we'll only get here, and thus close the file
+           descriptor, if EPOLLIN was not set. This ensures that all
+           outstanding input (possibly more than MAX_BUF bytes) is
+           consumed (by further loop iterations) before the file
+           descriptor is closed. */
+
+        std::cout << "    closing fd " << evlist[j].data.fd << std::endl;
+
+        if (close(evlist[j].data.fd) == -1) {
+          std::cerr << "close failed" << std::endl;
+          exit(EXIT_FAILURE);
+        }
+        numOpenFds--;
+      }
+    }
+  }
+
+  std::cout << "All file descriptors closed; bye" << std::endl;
+  return 0;
+}

--- a/test/playground/syagi/03_io/epoll.cpp
+++ b/test/playground/syagi/03_io/epoll.cpp
@@ -38,7 +38,10 @@ int main(int argc, char* argv[]) {
     std::cout << "Usage: " << argv[0] << " file...\n";
   }
 
-  int epfd = epoll_create(argc - 1);
+  //   int epfd = epoll_create(argc - 1);
+  // epoll_create1の方が良いらしい
+  // https://ja.manpages.org/epoll_create/2
+  int epfd = epoll_create1(EPOLL_CLOEXEC);
   if (epfd == -1) {
     std::cerr << "epoll_create failed\n";
     exit(EXIT_FAILURE);


### PR DESCRIPTION
単純に受け取ったデータをそのまま他のクライアントにそのまま流す処理を作りました。
ちょっとまだコードが汚いですが、何もないと書き始めづらいと思うので、一旦プルリクを送ります。

# 使い方
サーバーの起動
```shell
$ ./ircserv 6677 password123
```

クライアントの接続
```shell
$ nc -C 127.0.0.1 6677
```
3,4個ターミナルを開いて、クライアントを接続して下さい。
適当に文字を打って、エンター（またはCtrl + D）を押すと、
他のクライアントにデータが送信されます。

# 今後
void CommandHandler::handleCommand(const IRCMessage& msg);
がデータをそのまま他のクライアントに流す処理になっているので、
この部分でメッセージをパースして、IRCの仕様に沿って、
各コマンドの処理に分岐させるところの開発をお願いします。

IRCクライアントで接続すると、クライアントがどんなコマンドを送ってきているのか、確認することができます。
```shell
$ irssi --connect=127.0.0.1 --port=6677 --nick=user2
```
```
DEBUG: CommandHandler::handleCommand from: 5
----------------------
CAP LS 302
JOIN :
----------------------
```
irssiの場合、最初にCAPというコマンドでサーバーが使用できるコマンドを確認しに来るようです。

# TODO
現在、受け取ったデータをそのままIRCMessageに詰めて、CommandHandlerに渡していますが、
CRLFごとにIRCMessageを分けてハンドラーに渡す予定です。


