### PR TITLE
単体テストを追加しました

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 	"forwardPorts": [6667, 6677, 6777],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y netcat ngircd tcpdump",
+	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y netcat ngircd tcpdump cmake",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ ircserv
 
 *.orig
 *.bin
+
+test/unit/build/*

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,15 @@ fclean: clean
 
 .PHONY: re
 re: fclean all
+
+.PHONY: run
+run: all
+	./$(NAME) 6677 pass123
+
+.PHONY: unit_test
+unit_test:
+	cd test/unit \
+	&& cmake -S . -B build \
+	&& cmake --build build \
+	&& cd build \
+	&& ctest

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,7 @@ unit_test:
 	&& cmake --build build \
 	&& cd build \
 	&& ctest
+
+.PHONY: ngircd
+ngircd:
+	sudo service ngircd restart

--- a/include/ClientSession.hpp
+++ b/include/ClientSession.hpp
@@ -24,7 +24,7 @@ class ClientSession {
 
   int getFd() const;
   const std::string& getNickName() const;
-  // void setNickName(const std::string& nick);
+  void setNickName(const std::string& nick);
   // void setUserInfo(const std::string& user, const std::string& real);
   // bool isRegistered() const;
 

--- a/include/CommandHandler.hpp
+++ b/include/CommandHandler.hpp
@@ -11,7 +11,6 @@ class CommandHandler {
   IRCServer* server_;
 
  private:
-  // void handleNick(ClientSession* client, const IRCMessage& message);
   // void handleUser(ClientSession* client, const IRCMessage& message);
   // void handleJoin(ClientSession* client, const IRCMessage& message);
   // void handlePrivmsg(ClientSession* client, const IRCMessage& message);
@@ -19,7 +18,6 @@ class CommandHandler {
   // void handleQuit(ClientSession* client, const IRCMessage& message);
   // void handlePing(ClientSession* client, const IRCMessage& message);
   // void handlePong(ClientSession* client, const IRCMessage& message);
-  void broadCastRawMsg(IRCMessage& msg);
 
  public:
   CommandHandler(IRCServer* server);
@@ -28,6 +26,8 @@ class CommandHandler {
   CommandHandler& operator=(const CommandHandler& other);
 
   void handleCommand(IRCMessage& msg);
+  void broadCastRawMsg(IRCMessage& msg);
+  void handleNick(IRCMessage& msg);
 };
 
 #endif  // __COMMAND_HANDLER_HPP__

--- a/include/CommandHandler.hpp
+++ b/include/CommandHandler.hpp
@@ -19,7 +19,7 @@ class CommandHandler {
   // void handleQuit(ClientSession* client, const IRCMessage& message);
   // void handlePing(ClientSession* client, const IRCMessage& message);
   // void handlePong(ClientSession* client, const IRCMessage& message);
-  void broadCastRawMsg(const IRCMessage& msg);
+  void broadCastRawMsg(IRCMessage& msg);
 
  public:
   CommandHandler(IRCServer* server);
@@ -27,7 +27,7 @@ class CommandHandler {
   CommandHandler(const CommandHandler& other);
   CommandHandler& operator=(const CommandHandler& other);
 
-  void handleCommand(const IRCMessage& msg);
+  void handleCommand(IRCMessage& msg);
 };
 
 #endif  // __COMMAND_HANDLER_HPP__

--- a/include/IRCMessage.hpp
+++ b/include/IRCMessage.hpp
@@ -26,7 +26,7 @@ class IRCMessage {
   // bool parse(); // rawMessageを解析してprefix, command, paramsに分解
   // std::string toString() const;  // メッセージの文字列化
 
-  ClientSession* const getFrom() const;
+  ClientSession* getFrom() const;
   const std::string& getRaw() const;
   const std::map<ClientSession*, std::string>& getResponses() const;
 

--- a/include/IRCMessage.hpp
+++ b/include/IRCMessage.hpp
@@ -2,6 +2,7 @@
 #ifndef __IRC_MESSAGE_HPP__
 #define __IRC_MESSAGE_HPP__
 
+#include <map>
 #include <string>
 #include "ClientSession.hpp"
 
@@ -9,6 +10,8 @@ class IRCMessage {
  private:
   ClientSession* from_;
   std::string raw_;
+  // 宛先client->送信メッセージのmap
+  std::map<ClientSession*, std::string> responses_;
   // std::string prefix_;
   // std::string command_;
   // std::vector params_;
@@ -25,10 +28,13 @@ class IRCMessage {
 
   const ClientSession* getFrom() const;
   const std::string& getRaw() const;
+  const std::map<ClientSession*, std::string>& getResponses() const;
+
   // const std::string& getCommand() const;
   // const std::vector& getParams() const;
   // const std::string& getPrefix() const;
   bool isFromMe(const ClientSession* client) const;
+  void addResponse(ClientSession* client, const std::string& response);
 };
 
 #endif  // __IRC_MESSAGE_HPP__

--- a/include/IRCMessage.hpp
+++ b/include/IRCMessage.hpp
@@ -26,7 +26,7 @@ class IRCMessage {
   // bool parse(); // rawMessageを解析してprefix, command, paramsに分解
   // std::string toString() const;  // メッセージの文字列化
 
-  const ClientSession* getFrom() const;
+  ClientSession* const getFrom() const;
   const std::string& getRaw() const;
   const std::map<ClientSession*, std::string>& getResponses() const;
 

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -37,7 +37,8 @@ class IRCServer {
   // void disconnectClient(ClientSession* client);
 
   // clients_を取得
-  std::map<int, ClientSession*>& getClients();
+  const std::map<int, ClientSession*>& getClients() const;
+  void addClient(ClientSession* client);
 };
 
 #endif  // __IRC_SERVER_HPP__

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <string>
 #include "ClientSession.hpp"
+#include "IRCMessage.hpp"
 #include "Socket.hpp"
 
 #define EPOLL_MAX_EVENTS 10
@@ -20,6 +21,7 @@ class IRCServer {
   // ChannelManager channelManager_;
   // Logger logger_;
   void acceptConnection(int listenSocketFd);
+  void sendResponses(const IRCMessage& msg);
 
  public:
   IRCServer(const char* port, const char* password);

--- a/src/ClientSession.cpp
+++ b/src/ClientSession.cpp
@@ -18,3 +18,11 @@ void ClientSession::sendMessage(const std::string& msg) {
 int ClientSession::getFd() const {
   return socket_.getFd();
 }
+
+const std::string& ClientSession::getNickName() const {
+  return nickName_;
+}
+
+void ClientSession::setNickName(const std::string& nick) {
+  nickName_ = nick;
+}

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -16,7 +16,7 @@ CommandHandler& CommandHandler::operator=(const CommandHandler& other) {
 }
 
 void CommandHandler::broadCastRawMsg(IRCMessage& msg) {
-  for (std::map<int, ClientSession*>::iterator it =
+  for (std::map<int, ClientSession*>::const_iterator it =
            server_->getClients().begin();
        it != server_->getClients().end(); ++it) {
     if (msg.isFromMe(it->second)) {
@@ -29,6 +29,11 @@ void CommandHandler::broadCastRawMsg(IRCMessage& msg) {
   }
 }
 
+void CommandHandler::handleNick(IRCMessage& msg) {
+  // TODO NICKコマンドの処理をちゃんと書く
+  msg.getFrom()->setNickName("nick1");
+}
+
 void CommandHandler::handleCommand(IRCMessage& msg) {
   DEBUG_MSG("CommandHandler::handleCommand from: "
             << msg.getFrom()->getFd() << std::endl
@@ -36,6 +41,10 @@ void CommandHandler::handleCommand(IRCMessage& msg) {
             << msg.getRaw() << "----------------------");
 
   // TODO コマンドを解析して処理を分岐
+  if (msg.getRaw() == "NICK nick1") {
+    handleNick(msg);
+    return;
+  }
   // 受信したデータを他のクライアントにそのまま送信
   broadCastRawMsg(msg);
 }

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -15,7 +15,7 @@ CommandHandler& CommandHandler::operator=(const CommandHandler& other) {
   return *this;
 }
 
-void CommandHandler::broadCastRawMsg(const IRCMessage& msg) {
+void CommandHandler::broadCastRawMsg(IRCMessage& msg) {
   for (std::map<int, ClientSession*>::iterator it =
            server_->getClients().begin();
        it != server_->getClients().end(); ++it) {
@@ -24,12 +24,12 @@ void CommandHandler::broadCastRawMsg(const IRCMessage& msg) {
       continue;
     } else {
       // 受信したデータを他のクライアントにそのまま送信
-      it->second->sendMessage(msg.getRaw());
+      msg.addResponse(it->second, msg.getRaw());
     }
   }
 }
 
-void CommandHandler::handleCommand(const IRCMessage& msg) {
+void CommandHandler::handleCommand(IRCMessage& msg) {
   DEBUG_MSG("CommandHandler::handleCommand from: "
             << msg.getFrom()->getFd() << std::endl
             << "----------------------" << std::endl

--- a/src/IRCMessage.cpp
+++ b/src/IRCMessage.cpp
@@ -20,7 +20,7 @@ IRCMessage& IRCMessage::operator=(const IRCMessage& other) {
   return *this;
 }
 
-const ClientSession* IRCMessage::getFrom() const {
+ClientSession* const IRCMessage::getFrom() const {
   return from_;
 }
 

--- a/src/IRCMessage.cpp
+++ b/src/IRCMessage.cpp
@@ -20,7 +20,7 @@ IRCMessage& IRCMessage::operator=(const IRCMessage& other) {
   return *this;
 }
 
-ClientSession* const IRCMessage::getFrom() const {
+ClientSession* IRCMessage::getFrom() const {
   return from_;
 }
 

--- a/src/IRCMessage.cpp
+++ b/src/IRCMessage.cpp
@@ -28,6 +28,15 @@ const std::string& IRCMessage::getRaw() const {
   return raw_;
 }
 
+const std::map<ClientSession*, std::string>& IRCMessage::getResponses() const {
+  return responses_;
+}
+
 bool IRCMessage::isFromMe(const ClientSession* client) const {
   return from_ == client;
+}
+
+void IRCMessage::addResponse(ClientSession* client_to,
+                             const std::string& message) {
+  responses_[client_to] = message;
 }

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -131,6 +131,14 @@ void IRCServer::acceptConnection(int listenSocketFd) {
   }
 }
 
+void IRCServer::sendResponses(const IRCMessage& msg) {
+  for (std::map<ClientSession*, std::string>::const_iterator it =
+           msg.getResponses().begin();
+       it != msg.getResponses().end(); ++it) {
+    it->first->sendMessage(it->second);
+  }
+}
+
 void IRCServer::run() {
   CommandHandler commandHandler(this);
 
@@ -164,6 +172,7 @@ void IRCServer::run() {
           if (bytesRead > 0) {
             IRCMessage msg(it_from->second, std::string(buffer, bytesRead));
             commandHandler.handleCommand(msg);
+            sendResponses(msg);
           } else if (bytesRead == 0) {
             // クライアントが切断された場合
             // クライアントセッションを削除 & ソケットクローズ

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -118,9 +118,7 @@ void IRCServer::acceptConnection(int listenSocketFd) {
   sockaddr_storage addr;
   socklen_t addrlen = sizeof(addr);
   int sockfd = accept(listenSocketFd, (struct sockaddr*)&addr, &addrlen);
-  clients_[sockfd] = new ClientSession(sockfd);
-  DEBUG_MSG("New client connected: " << sockfd
-                                     << ", client num: " << clients_.size());
+  addClient(new ClientSession(sockfd));
 
   // クライアントのソケットをepollで監視
   struct epoll_event ev;
@@ -198,6 +196,12 @@ void IRCServer::run() {
   }
 }
 
-std::map<int, ClientSession*>& IRCServer::getClients() {
+const std::map<int, ClientSession*>& IRCServer::getClients() const {
   return clients_;
+}
+
+void IRCServer::addClient(ClientSession* client) {
+  clients_[client->getFd()] = client;
+  DEBUG_MSG("New client connected: " << client->getFd()
+                                     << ", client num: " << clients_.size());
 }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,0 +1,55 @@
+# https://google.github.io/googletest/quickstart-cmake.html
+# テスト環境構築 ############################################################################################
+cmake_minimum_required(VERSION 3.14)
+project(my_project)
+
+# GoogleTest requires at least C++17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+
+# ft_irc関連のソースをgoogleTestに追加 ############################################################################################
+file(GLOB_RECURSE LIB_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ../../src/*.cpp)
+
+# main.cを除外
+list(REMOVE_ITEM LIB_SRCS ../../src/main.cpp)
+
+add_library(libftirc ${LIB_SRCS})
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DREADLINE_LIBRARY -O0 -g")
+include_directories(
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../include"
+)
+
+# テストファイルのビルド ############################################################################################
+file(GLOB_RECURSE TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ./src/*.cpp)
+
+foreach(testSrc ${TEST_SRCS})
+  # Extract the filename without an extension (NAME_WE)
+  get_filename_component(testName ${testSrc} NAME_WE)
+
+  # Add compile target
+  add_executable(${testName} ${testSrc})
+
+  # Link to GoogleTest
+  target_link_libraries(${testName} GTest::gtest_main libftirc)
+
+  # Move testing binaries into a testBin directory
+  set_target_properties(${testName} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
+
+  # Add it to test execution
+  add_test(NAME ${testName}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/bin/${testName})
+endforeach(testSrc)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -26,9 +26,12 @@ list(REMOVE_ITEM LIB_SRCS ../../src/main.cpp)
 
 add_library(libftirc ${LIB_SRCS})
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DREADLINE_LIBRARY -O0 -g")
+target_compile_definitions(libftirc PRIVATE UNIT_TEST)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g")
 include_directories(
   "${CMAKE_CURRENT_SOURCE_DIR}/../../include"
+  # "${CMAKE_CURRENT_SOURCE_DIR}/build/_deps/googletest-src/googletest/include"
 )
 
 # テストファイルのビルド ############################################################################################
@@ -43,6 +46,9 @@ foreach(testSrc ${TEST_SRCS})
 
   # Link to GoogleTest
   target_link_libraries(${testName} GTest::gtest_main libftirc)
+
+  # マクロ定義
+  target_compile_definitions(${testName} PRIVATE UNIT_TEST)
 
   # Move testing binaries into a testBin directory
   set_target_properties(${testName} PROPERTIES

--- a/test/unit/src/CommandHandler/broadCastRawMsg.cpp
+++ b/test/unit/src/CommandHandler/broadCastRawMsg.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+#include "CommandHandler.hpp"
+#include "IRCServer.hpp"
+
+TEST(CommandHandler, broadCastRawMsg) {
+  IRCServer server("6677", "pass123");
+
+  std::map<int, ClientSession*> clients;
+  clients[10] = new ClientSession(10);
+  clients[11] = new ClientSession(11);
+  clients[12] = new ClientSession(12);
+  server.addClient(clients[10]);
+  server.addClient(clients[11]);
+  server.addClient(clients[12]);
+
+  std::string msgStr = "abcdefg";
+  IRCMessage msg(clients[10], msgStr);
+
+  CommandHandler commandHandler(&server);
+  commandHandler.broadCastRawMsg(msg);
+
+  const std::map<ClientSession*, std::string> res = msg.getResponses();
+
+  EXPECT_EQ(res.size(), 2);
+
+  // 11, 12にそのままのメッセージが送信されていることを確認
+  EXPECT_EQ(res.at(clients[11]), msgStr);
+  EXPECT_EQ(res.at(clients[12]), msgStr);
+  // 10には送信されていないことを確認
+  EXPECT_EQ(res.find(clients[10]), res.end());
+}

--- a/test/unit/src/CommandHandler/handleNick.cpp
+++ b/test/unit/src/CommandHandler/handleNick.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+#include "CommandHandler.hpp"
+#include "IRCServer.hpp"
+
+TEST(CommandHandlerTE, handleNick1) {
+  IRCServer server("6677", "pass123");
+
+  std::map<int, ClientSession*> clients;
+  clients[10] = new ClientSession(10);
+  clients[11] = new ClientSession(11);
+  clients[12] = new ClientSession(12);
+  server.addClient(clients[10]);
+  server.addClient(clients[11]);
+  server.addClient(clients[12]);
+
+  std::string msgStr = "NICK nick1";
+  std::string expected = "nick1";
+  IRCMessage msg(clients[10], msgStr);
+
+  CommandHandler commandHandler(&server);
+  commandHandler.handleNick(msg);
+
+  const std::map<ClientSession*, std::string> res = msg.getResponses();
+
+  EXPECT_EQ(res.size(), 0);
+  EXPECT_EQ(server.getClients().at(10)->getNickName(), expected);
+}
+
+// TODO まだニックネームがnick1の時しか実装していないので、エラーになる
+// TEST(CommandHandlerTE, handleNick2) {
+//   IRCServer server("6677", "pass123");
+
+//   std::map<int, ClientSession*> clients;
+//   clients[10] = new ClientSession(10);
+//   clients[11] = new ClientSession(11);
+//   clients[12] = new ClientSession(12);
+//   server.addClient(clients[10]);
+//   server.addClient(clients[11]);
+//   server.addClient(clients[12]);
+
+//   std::string msgStr = "NICK nick2";
+//   std::string expected = "nick2";
+//   IRCMessage msg(clients[10], msgStr);
+
+//   CommandHandler commandHandler(&server);
+//   commandHandler.handleNick(msg);
+
+//   const std::map<ClientSession*, std::string> res = msg.getResponses();
+
+//   EXPECT_EQ(res.size(), 0);
+//   EXPECT_EQ(server.getClients().at(10)->getNickName(), expected);
+// }

--- a/test/unit/src/hello_test.cpp
+++ b/test/unit/src/hello_test.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+
+// Demonstrate some basic assertions.
+TEST(HelloTest, BasicAssertions) {
+  // Expect two strings not to be equal.
+  EXPECT_STRNE("hello", "world");
+  // Expect equality.
+  EXPECT_EQ(7 * 6, 42);
+}
+
+// bad test
+TEST(HelloTest2, BasicAssertions2) {
+  // Expect equality.
+  // EXPECT_EQ(1, 2);
+  EXPECT_EQ(1, 1);
+}


### PR DESCRIPTION
単体テストのためにGoogleTestを導入しました。

## 使い方
cmakeが必要なので、コンテナに入っていなかったら追加して下さい（devcontainer.jsonには追加しています。）
```bash
$ apt install cmake
$ make unit_test
```

## 設計の修正
前の設計では単体テストが書きにくかったため
CommandHandlerの中でsendするのではなく、
IRCMessageのresponses_に宛先とメッセージの内容をマップに設定して、
IRCServer側でsendするようにしました。

## 単体テストのサンプル
単体テストのサンプルとして、下記を追加しました。
handleNickのコードはダミーです。
test/unit/src/CommandHandler/broadCastRawMsg.cpp
test/unit/src/CommandHandler/handleNick.cpp

## 注意
単体テスト部分にC++11のコードが含まれています。
本番コードに含まれていなければ問題ないと思っていますが、
必要であれば、提出前に単体テストを消すでもいいと思います。
