### PR TITLE
IRCMessageをパースするIRCParserを追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,17 +4,17 @@
 	"name": "Ubuntu",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/base:jammy",
-
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-	"forwardPorts": [6667, 6677, 6777],
-
+	"forwardPorts": [
+		6667,
+		6677,
+		6777
+	],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y netcat ngircd tcpdump cmake",
-
+	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y netcat ngircd tcpdump cmake valgrind",
 	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {
@@ -27,8 +27,7 @@
 				"mhutchie.git-graph"
 			]
 		}
-	},
-
+	}
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 NAME := ircserv
 
 SRCS := src/main.cpp src/IRCServer.cpp src/ClientSession.cpp \
-		src/CommandHandler.cpp src/IRCMessage.cpp src/Socket.cpp
+		src/CommandHandler.cpp src/IRCMessage.cpp src/Socket.cpp \
+		src/IRCParser.cpp
 OBJS := $(SRCS:.cpp=.o)
 CXXFLAGS += -I./include -Wall -Wextra -Werror -O0 -g -std=c++98 -pedantic-errors -DDEBUG
 CXX := c++

--- a/include/IRCMessage.hpp
+++ b/include/IRCMessage.hpp
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-#include "IRCParser.hpp"
+// #include "IRCParser.hpp"
 #include "ClientSession.hpp"
 
 class IRCMessage {
@@ -17,7 +17,7 @@ class IRCMessage {
   std::map<ClientSession*, std::string> responses_; // 宛先client->送信メッセージのmap
   std::string prefix_;
   std::string command_;
-  bool isReply_;
+  // bool isReply_;
   std::vector<std::string> params_;
 
   // Constructor
@@ -36,7 +36,7 @@ class IRCMessage {
   const std::map<ClientSession*, std::string>& getResponses() const;
   const std::string& getPrefix() const;
   const std::string& getCommand() const;
-  bool isReply() const;
+  // bool getIsReply() const;
   const std::string& getParam(int index) const;
   const std::vector<std::string>& getParams() const;
 
@@ -44,7 +44,7 @@ class IRCMessage {
   void setRaw(const std::string& raw);
   void setPrefix(const std::string& prefix);
   void setCommand(const std::string& command);
-  void setReply(bool isReply);
+  // void setIsReply(bool isReply);
   void addParam(const std::string& param);
   void setParams(const std::vector<std::string>& params);
 

--- a/include/IRCMessage.hpp
+++ b/include/IRCMessage.hpp
@@ -4,35 +4,52 @@
 
 #include <map>
 #include <string>
+#include <vector>
+
+#include "IRCParser.hpp"
 #include "ClientSession.hpp"
 
 class IRCMessage {
  private:
+  // Member variables
   ClientSession* from_;
   std::string raw_;
-  // 宛先client->送信メッセージのmap
-  std::map<ClientSession*, std::string> responses_;
-  // std::string prefix_;
-  // std::string command_;
-  // std::vector params_;
+  std::map<ClientSession*, std::string> responses_; // 宛先client->送信メッセージのmap
+  std::string prefix_;
+  std::string command_;
+  bool isReply_;
+  std::vector<std::string> params_;
+
+  // Constructor
   IRCMessage();
 
  public:
+  // Orthodox Cannonical Form
   IRCMessage(ClientSession* from, const std::string& raw);
   ~IRCMessage();
   IRCMessage(const IRCMessage& other);
   IRCMessage& operator=(const IRCMessage& other);
 
-  // bool parse(); // rawMessageを解析してprefix, command, paramsに分解
-  // std::string toString() const;  // メッセージの文字列化
-
+  // Getters
   ClientSession* getFrom() const;
   const std::string& getRaw() const;
   const std::map<ClientSession*, std::string>& getResponses() const;
+  const std::string& getPrefix() const;
+  const std::string& getCommand() const;
+  bool isReply() const;
+  const std::string& getParam(int index) const;
+  const std::vector<std::string>& getParams() const;
 
-  // const std::string& getCommand() const;
-  // const std::vector& getParams() const;
-  // const std::string& getPrefix() const;
+  // Setters
+  void setRaw(const std::string& raw);
+  void setPrefix(const std::string& prefix);
+  void setCommand(const std::string& command);
+  void setReply(bool isReply);
+  void addParam(const std::string& param);
+  void setParams(const std::vector<std::string>& params);
+
+  // Member functions
+  // std::string toString() const;  // メッセージの文字列化
   bool isFromMe(const ClientSession* client) const;
   void addResponse(ClientSession* client, const std::string& response);
 };

--- a/include/IRCParser.hpp
+++ b/include/IRCParser.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#ifndef __IRC_PARSER_HPP__
+#define __IRC_PARSER_HPP__
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "IRCMessage.hpp"
+
+class IRCMessage;
+
+class IRCParser {
+ public:
+  static bool parseRaw(IRCMessage& msg);
+
+ private:
+  // Orthodox Cannonical Form
+  // IRCParser();
+  // ~IRCParser();
+  // IRCParser(const IRCParser& other);
+  // IRCParser& operator=(const IRCParser& other);
+
+  // Parsing functions
+  static bool parseClrf(IRCMessage& msg);
+  static bool extractPrefix(IRCMessage& msg, std::string::size_type& pos);
+  static bool extractCommand(IRCMessage& msg, std::string::size_type& pos);
+  static bool extractParams(IRCMessage& msg, std::string::size_type& pos);
+  static bool parsePrefix(const std::string& prefix);
+  static bool parseCommand(IRCMessage& msg, const std::string& command);
+};
+
+#endif  // __IRC_PARSER_HPP__

--- a/include/IRCParser.hpp
+++ b/include/IRCParser.hpp
@@ -27,7 +27,7 @@ class IRCParser {
   static bool extractCommand(IRCMessage& msg, std::string::size_type& pos);
   static bool extractParams(IRCMessage& msg, std::string::size_type& pos);
   static bool parsePrefix(const std::string& prefix);
-  static bool parseCommand(IRCMessage& msg, const std::string& command);
+  static bool validCommand(const std::string& command);
 };
 
 #endif  // __IRC_PARSER_HPP__

--- a/include/IRCParser.hpp
+++ b/include/IRCParser.hpp
@@ -22,7 +22,7 @@ class IRCParser {
   // IRCParser& operator=(const IRCParser& other);
 
   // Parsing functions
-  static bool parseClrf(IRCMessage& msg);
+  static bool parseCrlf(IRCMessage& msg);
   static bool extractPrefix(IRCMessage& msg, std::string::size_type& pos);
   static bool extractCommand(IRCMessage& msg, std::string::size_type& pos);
   static bool extractParams(IRCMessage& msg, std::string::size_type& pos);

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -4,8 +4,10 @@
 
 #include <map>
 #include <string>
+
 #include "ClientSession.hpp"
 #include "IRCMessage.hpp"
+#include "IRCParser.hpp"
 #include "Socket.hpp"
 
 #define EPOLL_MAX_EVENTS 10

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -1,11 +1,13 @@
 #include "CommandHandler.hpp"
+
 #include "IRCLogger.hpp"
 
+// Orthodox Cannonical Form
 CommandHandler::CommandHandler(IRCServer* server) : server_(server) {}
+
 CommandHandler::~CommandHandler() {}
-CommandHandler::CommandHandler(const CommandHandler& other) {
-  *this = other;
-}
+
+CommandHandler::CommandHandler(const CommandHandler& other) { *this = other; }
 
 CommandHandler& CommandHandler::operator=(const CommandHandler& other) {
   if (this == &other) {
@@ -15,6 +17,7 @@ CommandHandler& CommandHandler::operator=(const CommandHandler& other) {
   return *this;
 }
 
+// Member functions
 void CommandHandler::broadCastRawMsg(IRCMessage& msg) {
   for (std::map<int, ClientSession*>::const_iterator it =
            server_->getClients().begin();
@@ -24,7 +27,7 @@ void CommandHandler::broadCastRawMsg(IRCMessage& msg) {
       continue;
     } else {
       // 受信したデータを他のクライアントにそのまま送信
-      msg.addResponse(it->second, msg.getRaw());
+      msg.addResponse(it->second, msg.getRaw() + "\r\n");
     }
   }
 }
@@ -38,7 +41,12 @@ void CommandHandler::handleCommand(IRCMessage& msg) {
   DEBUG_MSG("CommandHandler::handleCommand from: "
             << msg.getFrom()->getFd() << std::endl
             << "----------------------" << std::endl
-            << msg.getRaw() << "----------------------");
+            << msg.getRaw() << std::endl
+            << "prefix: " << msg.getPrefix() << std::endl
+            << "command: " << msg.getCommand() << std::endl
+            << "param[0]: " << msg.getParam(0) << std::endl
+            << "param[1]: " << msg.getParam(1) << std::endl
+            << "----------------------");
 
   // TODO コマンドを解析して処理を分岐
   if (msg.getRaw() == "NICK nick1") {

--- a/src/IRCMessage.cpp
+++ b/src/IRCMessage.cpp
@@ -1,8 +1,15 @@
-
 #include "IRCMessage.hpp"
 
+// Orthodox Cannonical Form
 IRCMessage::IRCMessage(ClientSession* from, const std::string& raw)
-    : from_(from), raw_(raw) {}
+    : from_(from), raw_(raw), prefix_(""), command_("")
+    , isReply_(false), params_(std::vector<std::string>()) {
+  // rawMessageを解析してprefix, command, paramsに分解
+  if (!IRCParser::parseRaw(*this)) {
+    // TODO: 解析に失敗した場合の処理
+    // 例外を投げるか、エラーメッセージを返すなど
+  }
+}
 
 IRCMessage::~IRCMessage() {}
 
@@ -16,10 +23,15 @@ IRCMessage& IRCMessage::operator=(const IRCMessage& other) {
   }
   from_ = other.from_;
   raw_ = other.raw_;
-
+  responses_ = other.responses_;
+  prefix_ = other.prefix_;
+  command_ = other.command_;
+  isReply_ = other.isReply_;
+  params_ = other.params_;
   return *this;
 }
 
+// Getters
 ClientSession* IRCMessage::getFrom() const {
   return from_;
 }
@@ -32,6 +44,59 @@ const std::map<ClientSession*, std::string>& IRCMessage::getResponses() const {
   return responses_;
 }
 
+const std::string& IRCMessage::getPrefix() const {
+  return prefix_;
+}
+
+const std::string& IRCMessage::getCommand() const {
+  return command_;
+}
+
+bool IRCMessage::isReply() const {
+  return isReply_;
+}
+
+const std::string& IRCMessage::getParam(int index) const {
+  static const std::string empty = "";
+  if (params_.empty()) // paramsが空の場合のガード
+    return empty; 
+  if (index < 0 || index >= static_cast<int>(params_.size()))
+    return params_[0]; // TODO: 例外を投げるか、エラーメッセージを返すなど
+  return params_[index];
+}
+
+const std::vector<std::string>& IRCMessage::getParams() const {
+  return params_;
+}
+
+
+// Setters
+void IRCMessage::setRaw(const std::string& raw) {
+  raw_ = raw;
+}
+
+void IRCMessage::setPrefix(const std::string& prefix) {
+  prefix_ = prefix;
+}
+
+void IRCMessage::setCommand(const std::string& command) {
+  command_ = command;
+}
+
+void IRCMessage::setReply(bool isReply) {
+  isReply_ = isReply;
+}
+
+void IRCMessage::addParam(const std::string& param) {
+  params_.push_back(param);
+}
+
+void IRCMessage::setParams(
+    const std::vector<std::string>& params) {
+  params_ = params;
+}
+
+// Member functions
 bool IRCMessage::isFromMe(const ClientSession* client) const {
   return from_ == client;
 }

--- a/src/IRCMessage.cpp
+++ b/src/IRCMessage.cpp
@@ -3,12 +3,7 @@
 // Orthodox Cannonical Form
 IRCMessage::IRCMessage(ClientSession* from, const std::string& raw)
     : from_(from), raw_(raw), prefix_(""), command_("")
-    , isReply_(false), params_(std::vector<std::string>()) {
-  // rawMessageを解析してprefix, command, paramsに分解
-  if (!IRCParser::parseRaw(*this)) {
-    // TODO: 解析に失敗した場合の処理
-    // 例外を投げるか、エラーメッセージを返すなど
-  }
+    , params_(std::vector<std::string>()) {
 }
 
 IRCMessage::~IRCMessage() {}
@@ -26,7 +21,7 @@ IRCMessage& IRCMessage::operator=(const IRCMessage& other) {
   responses_ = other.responses_;
   prefix_ = other.prefix_;
   command_ = other.command_;
-  isReply_ = other.isReply_;
+  // isReply_ = other.isReply_;
   params_ = other.params_;
   return *this;
 }
@@ -52,9 +47,9 @@ const std::string& IRCMessage::getCommand() const {
   return command_;
 }
 
-bool IRCMessage::isReply() const {
-  return isReply_;
-}
+// bool IRCMessage::getIsReply() const {
+//   return isReply_;
+// }
 
 const std::string& IRCMessage::getParam(int index) const {
   static const std::string empty = "";
@@ -83,9 +78,9 @@ void IRCMessage::setCommand(const std::string& command) {
   command_ = command;
 }
 
-void IRCMessage::setReply(bool isReply) {
-  isReply_ = isReply;
-}
+// void IRCMessage::setIsReply(bool isReply) {
+//   isReply_ = isReply;
+// }
 
 void IRCMessage::addParam(const std::string& param) {
   params_.push_back(param);

--- a/src/IRCParser.cpp
+++ b/src/IRCParser.cpp
@@ -17,7 +17,8 @@ bool IRCParser::parseRaw(IRCMessage& msg) {
 bool IRCParser::parseCrlf(IRCMessage& msg) {
   std::string raw = msg.getRaw();
   std::string::size_type pos = raw.find("\r\n");
-  if (pos != raw.size() - 2) return false;
+  if (pos != raw.size() - 2)
+    return false;
   msg.setRaw(raw.substr(0, pos));
   return true;
 }
@@ -29,27 +30,32 @@ bool IRCParser::extractPrefix(IRCMessage& msg, std::string::size_type& pos) {
   std::string::size_type end = raw.find_first_of(" ", pos);
   prefix = raw.substr(1, end - 1);
   pos = raw.find_first_not_of(" ", end);
-  if (!parsePrefix(prefix)) return false;
+  if (!parsePrefix(prefix))
+    return false;
   msg.setPrefix(prefix);
   return true;
 }
 
 bool IRCParser::extractCommand(IRCMessage& msg, std::string::size_type& pos) {
-  if (pos == std::string::npos) return true;
+  if (pos == std::string::npos)
+    return true;
   std::string raw = msg.getRaw();
   std::string command;
   pos = raw.find_first_not_of(" ", pos);
   std::string::size_type end = raw.find_first_of(" ", pos);
-  if (pos == std::string::npos) return false;
+  if (pos == std::string::npos)
+    return false;
   command = raw.substr(pos, end - pos);
   pos = raw.find_first_not_of(" ", end);
-  if (!parseCommand(msg, command)) return false;
+  if (!validCommand(command))
+    return false;
   msg.setCommand(command);
   return true;
 }
 
 bool IRCParser::extractParams(IRCMessage& msg, std::string::size_type& pos) {
-  if (pos == std::string::npos) return true;
+  if (pos == std::string::npos)
+    return true;
   std::string raw = msg.getRaw();
   std::string param;
   std::string::size_type end;
@@ -71,18 +77,18 @@ bool IRCParser::extractParams(IRCMessage& msg, std::string::size_type& pos) {
 }
 
 bool IRCParser::parsePrefix(const std::string& prefix) {
-  if (prefix.empty()) return false;
+  if (prefix.empty())
+    return false;
   // TODO: prefixの解析を追加
   return true;
 }
 
-bool IRCParser::parseCommand(IRCMessage& msg, const std::string& command) {
-  if (command.empty()) return false;
-  // TODO: コマンドの解析を追加
-  if (command.find_first_not_of("0123456789") != std::string::npos &&
-      command.size() == 3) {
-    msg.setReply(true);
+bool IRCParser::validCommand(const std::string& command) {
+  if (command.empty())
+    return false;
+  if (command.find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ") != std::string::npos)
     return true;
-  }
-  return true;
+  if (command.find_first_not_of("0123456789") != std::string::npos && command.size() == 3)
+    return true;
+  return false;
 }

--- a/src/IRCParser.cpp
+++ b/src/IRCParser.cpp
@@ -1,0 +1,100 @@
+#include "IRCParser.hpp"
+
+bool IRCParser::parseRaw(IRCMessage& msg) {
+  std::string::size_type pos = 0;
+  std::string raw = msg.getRaw();
+  // extract clrf
+  if (!parseClrf(msg))
+    return false;
+  // extract prefix
+  if (!extractPrefix(msg, pos))
+    return false;
+  // extract command
+  if (!extractCommand(msg, pos))
+    return false;
+  // extract params
+  if (!extractParams(msg, pos))
+    return false;
+  return true;
+}
+
+bool IRCParser::parseClrf(IRCMessage& msg) {
+  std::string raw = msg.getRaw();
+  std::string::size_type pos = raw.find("\r\n");
+  if (pos != raw.size() - 2)
+    return false;
+  msg.setRaw(raw.substr(0, pos));
+  return true;
+}
+
+bool IRCParser::extractPrefix(IRCMessage& msg, std::string::size_type& pos) {
+  if (msg.getRaw()[pos] != ':' || pos == std::string::npos)
+    return true;
+  std::string raw = msg.getRaw();
+  std::string prefix;
+  std::string::size_type end = raw.find_first_of(" ", pos);
+  prefix = raw.substr(1, end - 1);
+  pos = raw.find_first_not_of(" ", end);
+  if (!parsePrefix(prefix))
+    return false;
+  msg.setPrefix(prefix);
+  return true;
+}
+
+bool IRCParser::extractCommand(IRCMessage& msg, std::string::size_type& pos) {
+  if (pos == std::string::npos)
+    return true;
+  std::string raw = msg.getRaw();
+  std::string command;
+  pos = raw.find_first_not_of(" ", pos);
+  std::string::size_type end = raw.find_first_of(" ", pos);
+  if (pos == std::string::npos)
+    return false;
+  command = raw.substr(pos, end - pos);
+  pos = raw.find_first_not_of(" ", end);
+  if (!parseCommand(msg, command))
+    return false;
+  msg.setCommand(command);
+  return true;
+}
+
+bool IRCParser::extractParams(IRCMessage& msg, std::string::size_type& pos) {
+  if (pos == std::string::npos)
+    return true;
+  std::string raw = msg.getRaw();
+  std::string param;
+  std::string::size_type end;
+  int paramCount = 0;
+  while (pos != std::string::npos && paramCount < 15) {
+      end = raw.find_first_of(" ", pos);
+    if (raw[pos] == ':') {
+      param = raw.substr(pos + 1);
+      msg.addParam(param);
+      break;
+    } else {
+      param = raw.substr(pos, end - pos);
+    }
+    pos = raw.find_first_not_of(" ", end);
+    msg.addParam(param);
+    paramCount++;
+  }
+    return true;
+}
+
+bool IRCParser::parsePrefix(const std::string& prefix) {
+  if (prefix.empty())
+    return false;
+  // TODO: prefixの解析を追加
+  return true;
+}
+
+bool IRCParser::parseCommand(IRCMessage& msg, const std::string& command) {
+  if (command.empty())
+    return false;
+  // TODO: コマンドの解析を追加
+    if (command.find_first_not_of("0123456789") != std::string::npos && command.size() == 3) {
+    msg.setReply(true);
+    return true;
+  }
+  return true;
+}

--- a/src/IRCParser.cpp
+++ b/src/IRCParser.cpp
@@ -3,70 +3,59 @@
 bool IRCParser::parseRaw(IRCMessage& msg) {
   std::string::size_type pos = 0;
   std::string raw = msg.getRaw();
-  // extract clrf
-  if (!parseClrf(msg))
-    return false;
+  // extract Crlf
+  if (!parseCrlf(msg)) return false;
   // extract prefix
-  if (!extractPrefix(msg, pos))
-    return false;
+  if (!extractPrefix(msg, pos)) return false;
   // extract command
-  if (!extractCommand(msg, pos))
-    return false;
+  if (!extractCommand(msg, pos)) return false;
   // extract params
-  if (!extractParams(msg, pos))
-    return false;
+  if (!extractParams(msg, pos)) return false;
   return true;
 }
 
-bool IRCParser::parseClrf(IRCMessage& msg) {
+bool IRCParser::parseCrlf(IRCMessage& msg) {
   std::string raw = msg.getRaw();
   std::string::size_type pos = raw.find("\r\n");
-  if (pos != raw.size() - 2)
-    return false;
+  if (pos != raw.size() - 2) return false;
   msg.setRaw(raw.substr(0, pos));
   return true;
 }
 
 bool IRCParser::extractPrefix(IRCMessage& msg, std::string::size_type& pos) {
-  if (msg.getRaw()[pos] != ':' || pos == std::string::npos)
-    return true;
+  if (msg.getRaw()[pos] != ':' || pos == std::string::npos) return true;
   std::string raw = msg.getRaw();
   std::string prefix;
   std::string::size_type end = raw.find_first_of(" ", pos);
   prefix = raw.substr(1, end - 1);
   pos = raw.find_first_not_of(" ", end);
-  if (!parsePrefix(prefix))
-    return false;
+  if (!parsePrefix(prefix)) return false;
   msg.setPrefix(prefix);
   return true;
 }
 
 bool IRCParser::extractCommand(IRCMessage& msg, std::string::size_type& pos) {
-  if (pos == std::string::npos)
-    return true;
+  if (pos == std::string::npos) return true;
   std::string raw = msg.getRaw();
   std::string command;
   pos = raw.find_first_not_of(" ", pos);
   std::string::size_type end = raw.find_first_of(" ", pos);
-  if (pos == std::string::npos)
-    return false;
+  if (pos == std::string::npos) return false;
   command = raw.substr(pos, end - pos);
   pos = raw.find_first_not_of(" ", end);
-  if (!parseCommand(msg, command))
-    return false;
+  if (!parseCommand(msg, command)) return false;
   msg.setCommand(command);
   return true;
 }
 
 bool IRCParser::extractParams(IRCMessage& msg, std::string::size_type& pos) {
-  if (pos == std::string::npos)
-    return true;
+  if (pos == std::string::npos) return true;
   std::string raw = msg.getRaw();
   std::string param;
   std::string::size_type end;
   int paramCount = 0;
   while (pos != std::string::npos && paramCount < 15) {
-      end = raw.find_first_of(" ", pos);
+    end = raw.find_first_of(" ", pos);
     if (raw[pos] == ':') {
       param = raw.substr(pos + 1);
       msg.addParam(param);
@@ -78,21 +67,20 @@ bool IRCParser::extractParams(IRCMessage& msg, std::string::size_type& pos) {
     msg.addParam(param);
     paramCount++;
   }
-    return true;
+  return true;
 }
 
 bool IRCParser::parsePrefix(const std::string& prefix) {
-  if (prefix.empty())
-    return false;
+  if (prefix.empty()) return false;
   // TODO: prefixの解析を追加
   return true;
 }
 
 bool IRCParser::parseCommand(IRCMessage& msg, const std::string& command) {
-  if (command.empty())
-    return false;
+  if (command.empty()) return false;
   // TODO: コマンドの解析を追加
-    if (command.find_first_not_of("0123456789") != std::string::npos && command.size() == 3) {
+  if (command.find_first_not_of("0123456789") != std::string::npos &&
+      command.size() == 3) {
     msg.setReply(true);
     return true;
   }

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -169,6 +169,7 @@ void IRCServer::run() {
           ssize_t bytesRead = recv(it_from->first, buffer, sizeof(buffer), 0);
           if (bytesRead > 0) {
             IRCMessage msg(it_from->second, std::string(buffer, bytesRead));
+            IRCParser::parseRaw(msg);
             commandHandler.handleCommand(msg);
             sendResponses(msg);
           } else if (bytesRead == 0) {


### PR DESCRIPTION
- IRCMessageをパースするIRCParserを追加
- .devcontainer に`valgrind`を追加

## 設計変更
IRCMessage内に生文章とパースしたデータを保存するようにしました。
IRCMessageのコンストラクタ呼び出し時にIRCParserクラスを呼び出し、パースしたデータを格納しています。
※データを利用しやすくするため、パース時に生データ上末尾のCRLF(`/r/n`)をチェック＆上書き削除しています。

```cpp
class IRCMessage {
 private:
  ...
  std::string raw_;
  std::string prefix_;
  std::string command_;
  bool isReply_;
  std::vector<std::string> params_;
```

## 今後の設計メモ
### IRCMessageの利用
生メッセージとパースしたものを同時に持つことで、IRCMessageを受信送信両方に簡単に利用できるようにしたい
- 受信時：生メッセージをパラメーターにもつコンストラクタ → パースして内部利用
- 送信時：コマンドと送信パラメータをパラメーターにもつコンストラクタ → IRCMessage内部関数(`genRaw()`みたいな)で生メッセージを作成
※そう考えるとparamの`trailing`と`middle`は今後分ける必要があるかも

## 課題（≒TODO）
- パースしたデータが正しい構文かどうかの判断はできていない（ある程度できたところで再考予定）
- 次はコマンドの実行部分を作ろうと思います。
- prefixのパースも追加したい

## 気になる
- 他クライアントに生メッセージ送信時に、時たま空メッセージが送られてしまう？（時々出るが、発生条件＆原因が不明）
- （Discordで会話済）IRCMessageの生メッセージでのコンストラクタ呼び出し時は全長の生メッセージが渡される前提（IRCServer側で対応）