### PR TITLE
E2Eテスト追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,11 @@
 		6777
 	],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y netcat ngircd tcpdump cmake valgrind",
+	"postCreateCommand": [
+		"sudo apt-get update",
+		"sudo apt-get install -y netcat ngircd tcpdump cmake valgrind python3-pip irssi",
+		"pip install -U pytest"
+	],
 	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,11 +14,7 @@
 		6777
 	],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": [
-		"sudo apt-get update",
-		"sudo apt-get install -y netcat ngircd tcpdump cmake valgrind python3-pip irssi",
-		"pip install -U pytest"
-	],
+	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y netcat ngircd tcpdump cmake valgrind python3-pip irssi && pip install -U pytest",
 	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ ircserv
 *.bin
 
 test/unit/build/*
+
+__pycache__
+*.log

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,6 @@ fclean: clean
 .PHONY: re
 re: fclean all
 
-.PHONY: run
-run: all
-	./$(NAME) 6677 pass123
-
 .PHONY: unit_test
 unit_test:
 	cd test/unit \
@@ -36,6 +32,26 @@ unit_test:
 	&& cd build \
 	&& ctest
 
+.PHONY: e2e_test
+e2e_test: all
+	cd test/e2e \
+	&& pytest -vs
+
 .PHONY: ngircd
 ngircd:
 	sudo service ngircd restart
+
+.PHONY: server
+server: all
+	./$(NAME) 6677 pass123
+
+.PHONY: client
+client: all
+	@printf "Please enter a nickname: "; \
+	read NICK; \
+	irssi --connect=127.0.0.1 --port=6677 --nick=$$NICK --password=pass123
+
+.PHONY: nc
+nc: all
+	nc -C 127.0.0.1 6677
+

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ SRCS := src/main.cpp src/IRCServer.cpp src/ClientSession.cpp \
 		src/IRCParser.cpp src/Utils.cpp
 OBJS := $(SRCS:.cpp=.o)
 CXXFLAGS += -I./include -Wall -Wextra -Werror -O0 -g -std=c++98 -pedantic-errors -DDEBUG
+ifdef PROD_FLG
+CXXFLAGS := -I./include -Wall -Wextra -Werror -O2 -std=c++98 -pedantic-errors
+endif
 CXX := c++
 
 .PHONY: all
@@ -33,7 +36,8 @@ unit_test:
 	&& ctest
 
 .PHONY: e2e_test
-e2e_test: all
+e2e_test:
+	$(MAKE) re PROD_FLG=1
 	cd test/e2e \
 	&& pytest -vs
 

--- a/include/CommandHandler.hpp
+++ b/include/CommandHandler.hpp
@@ -16,7 +16,6 @@ class CommandHandler {
   // void handlePrivmsg(ClientSession* client, const IRCMessage& message);
   // void handlePart(ClientSession* client, const IRCMessage& message);
   // void handleQuit(ClientSession* client, const IRCMessage& message);
-  // void handlePing(ClientSession* client, const IRCMessage& message);
   // void handlePong(ClientSession* client, const IRCMessage& message);
 
  public:
@@ -28,6 +27,7 @@ class CommandHandler {
   void handleCommand(IRCMessage& msg);
   void broadCastRawMsg(IRCMessage& msg);
   void handleNick(IRCMessage& msg);
+  void handlePing(IRCMessage& msg);
 };
 
 #endif  // __COMMAND_HANDLER_HPP__

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -28,8 +28,8 @@ class IRCServer {
   static const int BUFFER_SIZE = 1024;
   static const int MAX_MSG_SIZE = 510;  // IRCの仕様
 
-  static const int MAX_BACKLOG = 10;
-  static const int EPOLL_MAX_EVENTS = 10;
+  static const int MAX_BACKLOG = 100;
+  static const int EPOLL_MAX_EVENTS = 10000;
 
  public:
   IRCServer(const char* port, const char* password);

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -10,8 +10,6 @@
 #include "IRCParser.hpp"
 #include "Socket.hpp"
 
-#define EPOLL_MAX_EVENTS 10
-
 class IRCServer {
  private:
   int epfd_;  // epollのファイルディスクリプタ
@@ -29,6 +27,9 @@ class IRCServer {
 
   static const int BUFFER_SIZE = 1024;
   static const int MAX_MSG_SIZE = 510;  // IRCの仕様
+
+  static const int MAX_BACKLOG = 10;
+  static const int EPOLL_MAX_EVENTS = 10;
 
  public:
   IRCServer(const char* port, const char* password);

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -37,6 +37,11 @@ void CommandHandler::handleNick(IRCMessage& msg) {
   msg.getFrom()->setNickName("nick1");
 }
 
+void CommandHandler::handlePing(IRCMessage& msg) {
+  // TODO PINGコマンドの処理をちゃんと書く
+  msg.addResponse(msg.getFrom(), "PONG\r\n");
+}
+
 void CommandHandler::handleCommand(IRCMessage& msg) {
   DEBUG_MSG("CommandHandler::handleCommand from: "
             << msg.getFrom()->getFd() << std::endl
@@ -49,8 +54,11 @@ void CommandHandler::handleCommand(IRCMessage& msg) {
             << "----------------------");
 
   // TODO コマンドを解析して処理を分岐
-  if (msg.getRaw() == "NICK nick1") {
+  if (msg.getRaw().compare(0, 4, "NICK") == 0) {
     handleNick(msg);
+    return;
+  } else if (msg.getRaw().compare(0, 4, "PING") == 0) {
+    handlePing(msg);
     return;
   }
   // 受信したデータを他のクライアントにそのまま送信

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -125,6 +125,8 @@ void IRCServer::acceptConnection(int listenSocketFd) {
   ev.data.fd = sockfd;
   if (epoll_ctl(epfd_, EPOLL_CTL_ADD, sockfd, &ev) == -1) {
     std::cerr << "epoll_ctl failed" << std::endl;
+    close(sockfd);
+    return;
   }
 }
 

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -18,8 +18,6 @@
 #include "IRCMessage.hpp"
 #include "Utils.hpp"
 
-#define MAX_BACKLOG 5
-
 IRCServer::IRCServer(const char* port, const char* password) {
   epfd_ = epoll_create1(EPOLL_CLOEXEC);
   if (epfd_ == -1) {

--- a/test/e2e/many_clients_test.py
+++ b/test/e2e/many_clients_test.py
@@ -64,7 +64,7 @@ def test_many_clients():
     """
     多数クライアントが同時に接続でき、各クライアントが PING を送信できるかを確認する。
     """
-    num_clients = 1000
+    num_clients = 10000
     client_sockets = []
     threads = []
 

--- a/test/e2e/many_clients_test.py
+++ b/test/e2e/many_clients_test.py
@@ -6,33 +6,33 @@ import subprocess
 
 SERVER_HOST = "127.0.0.1"
 SERVER_PORT = 6677
+SERVER_PASSWORD = "pass123"
 
+## テスト開始時にサーバーを起動
+# def launch_server():
+#     """
+#     Launch the IRC server in a new process.
+#     """
+#     # Start the server with the specified port and password
+#     with open("e2e.log", "w") as logfile:
+#         process = subprocess.Popen(
+#             ["../../ircserv", str(SERVER_PORT), SERVER_PASSWORD],
+#             stdout=logfile,
+#             stderr=subprocess.STDOUT,
+#         )
+#     return process
 
-def launch_server():
-    """
-    Launch the IRC server in a new process.
-    """
-    # Start the server with the specified port and password
-    with open("e2e.log", "w") as logfile:
-        process = subprocess.Popen(
-            ["../../ircserv", "6677", "pass123"],
-            stdout=logfile,
-            stderr=subprocess.STDOUT,
-        )
-    return process
-
-
-@pytest.fixture(scope="session", autouse=True)
-def server_process():
-    """
-    テストセッション開始前にサーバーを起動し、セッション終了時にサーバーを停止するフィクスチャ。
-    """
-    process = launch_server()
-    # サーバーが起動するまで少し待機（適宜調整）
-    time.sleep(2)
-    yield process
-    process.terminate()
-    process.wait()
+# @pytest.fixture(scope="session", autouse=True)
+# def server_process():
+#     """
+#     テストセッション開始前にサーバーを起動し、セッション終了時にサーバーを停止するフィクスチャ。
+#     """
+#     process = launch_server()
+#     # サーバーが起動するまで少し待機（適宜調整）
+#     time.sleep(2)
+#     yield process
+#     process.terminate()
+#     process.wait()
 
 
 def connect_client(is_send_msg=True, is_hang=False):
@@ -46,13 +46,15 @@ def connect_client(is_send_msg=True, is_hang=False):
     if is_send_msg:
         s.sendall(b"PING\r\n")
     if is_hang:
-        # ハング状態をシミュレート：応答を待たずそのまま一定時間スリープ
+        # ハング状態をシミュレート　一定時間スリープ
         time.sleep(10)
-    # else:
-    #     try:
-    #         _ = s.recv(1024)
-    #     except Exception:
-    #         pass
+
+    if is_send_msg:
+        try:
+            data = s.recv(1024)
+            assert data == b"PONG\r\n", f"クライアントからの応答が不正: {data}"
+        except Exception as e:
+            pytest.fail(f"正常なクライアントの受信に失敗: {e}")
     return s
 
 
@@ -60,7 +62,10 @@ def test_many_clients():
     """
     多数クライアントが同時に接続でき、各クライアントが PING を送信できるかを確認する。
     """
+    # たまにうまくいくが、多くの場合固まる
     num_clients = 100
+    # 連続して実行すると固まることがある
+    # num_clients = 10
     client_sockets = []
     threads = []
 
@@ -80,65 +85,54 @@ def test_many_clients():
 
     assert len(client_sockets) == num_clients, "全てのクライアントが接続できなかった"
 
-    try:
-        for s in client_sockets:
-            data = "aaa"
-            # data = s.recv(1024)
-            # data = s.recv(4)
-            # print(f"------------data: {data}")
-            # assert data == b"PONG\r\n", f"クライアントからの応答が不正: {data}"
-            assert len(data) > 0, "正常なクライアントの応答が空"
-    except Exception as e:
-        pytest.fail(f"正常なクライアントの受信に失敗: {e}")
-    finally:
-        for s in client_sockets:
-            s.close()
+    for s in client_sockets:
+        s.close()
 
 
-def test_many_clients_with_hanging():
-    """
-    ハングしているクライアントが含まれている場合
-    """
-    num_clients = 10
-    client_sockets = []
-    hanging_sockets = []
-    threads = []
+# def test_many_clients_with_hanging():
+#     """
+#     ハングしているクライアントが含まれている場合
+#     """
+#     num_clients = 10
+#     client_sockets = []
+#     hanging_sockets = []
+#     threads = []
 
-    def client_worker(index):
-        try:
-            if index % 3 == 0:
-                s = connect_client(is_send_msg=False, is_hang=True)
-                hanging_sockets.append(s)
-            elif index % 3 == 1:
-                s = connect_client(is_send_msg=True, is_hang=True)
-                hanging_sockets.append(s)
-            else:
-                s = connect_client(is_send_msg=True, is_hang=False)
-                client_sockets.append(s)
-        except Exception as e:
-            pytest.fail(f"Client {index} failed to connect: {e}")
+#     def client_worker(index):
+#         try:
+#             if index % 3 == 0:
+#                 s = connect_client(is_send_msg=False, is_hang=True)
+#                 hanging_sockets.append(s)
+#             elif index % 3 == 1:
+#                 s = connect_client(is_send_msg=True, is_hang=True)
+#                 hanging_sockets.append(s)
+#             else:
+#                 s = connect_client(is_send_msg=True, is_hang=False)
+#                 client_sockets.append(s)
+#         except Exception as e:
+#             pytest.fail(f"Client {index} failed to connect: {e}")
 
-    for i in range(num_clients):
-        t = threading.Thread(target=client_worker, args=(i,))
-        threads.append(t)
-        t.start()
-    for t in threads:
-        t.join()
+#     for i in range(num_clients):
+#         t = threading.Thread(target=client_worker, args=(i,))
+#         threads.append(t)
+#         t.start()
+#     for t in threads:
+#         t.join()
 
-    assert (
-        len(client_sockets) + len(hanging_sockets)
-    ) == num_clients, "全てのクライアントが接続できなかった"
+#     assert (
+#         len(client_sockets) + len(hanging_sockets)
+#     ) == num_clients, "全てのクライアントが接続できなかった"
 
-    try:
-        for s in client_sockets:
-            data = "aaa"
-            # data = s.recv(1024)
-            # assert data == b"PONG\r\n", f"クライアントからの応答が不正: {data}"
-            assert len(data) > 0, "正常なクライアントの応答が空"
-    except Exception as e:
-        pytest.fail(f"正常なクライアントの受信に失敗: {e}")
-    finally:
-        for s in client_sockets:
-            s.close()
-        for s in hanging_sockets:
-            s.close()
+#     try:
+#         for s in client_sockets:
+#             data = "aaa"
+#             # data = s.recv(1024)
+#             # assert data == b"PONG\r\n", f"クライアントからの応答が不正: {data}"
+#             assert len(data) > 0, "正常なクライアントの応答が空"
+#     except Exception as e:
+#         pytest.fail(f"正常なクライアントの受信に失敗: {e}")
+#     finally:
+#         for s in client_sockets:
+#             s.close()
+#         for s in hanging_sockets:
+#             s.close()

--- a/test/e2e/many_clients_test.py
+++ b/test/e2e/many_clients_test.py
@@ -1,0 +1,144 @@
+import socket
+import threading
+import time
+import pytest
+import subprocess
+
+SERVER_HOST = "127.0.0.1"
+SERVER_PORT = 6677
+
+
+def launch_server():
+    """
+    Launch the IRC server in a new process.
+    """
+    # Start the server with the specified port and password
+    with open("e2e.log", "w") as logfile:
+        process = subprocess.Popen(
+            ["../../ircserv", "6677", "pass123"],
+            stdout=logfile,
+            stderr=subprocess.STDOUT,
+        )
+    return process
+
+
+@pytest.fixture(scope="session", autouse=True)
+def server_process():
+    """
+    テストセッション開始前にサーバーを起動し、セッション終了時にサーバーを停止するフィクスチャ。
+    """
+    process = launch_server()
+    # サーバーが起動するまで少し待機（適宜調整）
+    time.sleep(2)
+    yield process
+    process.terminate()
+    process.wait()
+
+
+def connect_client(is_send_msg=True, is_hang=False):
+    """
+    サーバーに接続し、必要に応じてメッセージ送信またはハング状態をシミュレートする。
+    is_send_msg が True の場合は "PING\r\n" を送信する。
+    is_hang が True の場合は、接続後に何もせず一定時間待機する。
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((SERVER_HOST, SERVER_PORT))
+    if is_send_msg:
+        s.sendall(b"PING\r\n")
+    if is_hang:
+        # ハング状態をシミュレート：応答を待たずそのまま一定時間スリープ
+        time.sleep(10)
+    # else:
+    #     try:
+    #         _ = s.recv(1024)
+    #     except Exception:
+    #         pass
+    return s
+
+
+def test_many_clients():
+    """
+    多数クライアントが同時に接続でき、各クライアントが PING を送信できるかを確認する。
+    """
+    num_clients = 100
+    client_sockets = []
+    threads = []
+
+    def client_worker(index):
+        try:
+            s = connect_client(is_send_msg=True, is_hang=False)
+            client_sockets.append(s)
+        except Exception as e:
+            pytest.fail(f"Client {index} failed to connect: {e}")
+
+    for i in range(num_clients):
+        t = threading.Thread(target=client_worker, args=(i,))
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(client_sockets) == num_clients, "全てのクライアントが接続できなかった"
+
+    try:
+        for s in client_sockets:
+            data = "aaa"
+            # data = s.recv(1024)
+            # data = s.recv(4)
+            # print(f"------------data: {data}")
+            # assert data == b"PONG\r\n", f"クライアントからの応答が不正: {data}"
+            assert len(data) > 0, "正常なクライアントの応答が空"
+    except Exception as e:
+        pytest.fail(f"正常なクライアントの受信に失敗: {e}")
+    finally:
+        for s in client_sockets:
+            s.close()
+
+
+def test_many_clients_with_hanging():
+    """
+    ハングしているクライアントが含まれている場合
+    """
+    num_clients = 10
+    client_sockets = []
+    hanging_sockets = []
+    threads = []
+
+    def client_worker(index):
+        try:
+            if index % 3 == 0:
+                s = connect_client(is_send_msg=False, is_hang=True)
+                hanging_sockets.append(s)
+            elif index % 3 == 1:
+                s = connect_client(is_send_msg=True, is_hang=True)
+                hanging_sockets.append(s)
+            else:
+                s = connect_client(is_send_msg=True, is_hang=False)
+                client_sockets.append(s)
+        except Exception as e:
+            pytest.fail(f"Client {index} failed to connect: {e}")
+
+    for i in range(num_clients):
+        t = threading.Thread(target=client_worker, args=(i,))
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert (
+        len(client_sockets) + len(hanging_sockets)
+    ) == num_clients, "全てのクライアントが接続できなかった"
+
+    try:
+        for s in client_sockets:
+            data = "aaa"
+            # data = s.recv(1024)
+            # assert data == b"PONG\r\n", f"クライアントからの応答が不正: {data}"
+            assert len(data) > 0, "正常なクライアントの応答が空"
+    except Exception as e:
+        pytest.fail(f"正常なクライアントの受信に失敗: {e}")
+    finally:
+        for s in client_sockets:
+            s.close()
+        for s in hanging_sockets:
+            s.close()

--- a/test/e2e/many_clients_test.py
+++ b/test/e2e/many_clients_test.py
@@ -64,10 +64,7 @@ def test_many_clients():
     """
     多数クライアントが同時に接続でき、各クライアントが PING を送信できるかを確認する。
     """
-    # たまにうまくいくが、多くの場合固まる
-    # num_clients = 100
-    # 連続して実行すると固まることがある
-    num_clients = 10
+    num_clients = 1000
     client_sockets = []
     threads = []
 

--- a/test/e2e/many_clients_test.py
+++ b/test/e2e/many_clients_test.py
@@ -8,31 +8,33 @@ SERVER_HOST = "127.0.0.1"
 SERVER_PORT = 6677
 SERVER_PASSWORD = "pass123"
 
-## テスト開始時にサーバーを起動
-# def launch_server():
-#     """
-#     Launch the IRC server in a new process.
-#     """
-#     # Start the server with the specified port and password
-#     with open("e2e.log", "w") as logfile:
-#         process = subprocess.Popen(
-#             ["../../ircserv", str(SERVER_PORT), SERVER_PASSWORD],
-#             stdout=logfile,
-#             stderr=subprocess.STDOUT,
-#         )
-#     return process
 
-# @pytest.fixture(scope="session", autouse=True)
-# def server_process():
-#     """
-#     テストセッション開始前にサーバーを起動し、セッション終了時にサーバーを停止するフィクスチャ。
-#     """
-#     process = launch_server()
-#     # サーバーが起動するまで少し待機（適宜調整）
-#     time.sleep(2)
-#     yield process
-#     process.terminate()
-#     process.wait()
+## テスト開始時にサーバーを起動
+def launch_server():
+    """
+    Launch the IRC server in a new process.
+    """
+    # Start the server with the specified port and password
+    with open("e2e.log", "w") as logfile:
+        process = subprocess.Popen(
+            ["../../ircserv", str(SERVER_PORT), SERVER_PASSWORD],
+            stdout=logfile,
+            stderr=subprocess.STDOUT,
+        )
+    return process
+
+
+@pytest.fixture(scope="session", autouse=True)
+def server_process():
+    """
+    テストセッション開始前にサーバーを起動し、セッション終了時にサーバーを停止するフィクスチャ。
+    """
+    process = launch_server()
+    # サーバーが起動するまで少し待機（適宜調整）
+    time.sleep(2)
+    yield process
+    process.terminate()
+    process.wait()
 
 
 def connect_client(is_send_msg=True, is_hang=False):
@@ -63,9 +65,9 @@ def test_many_clients():
     多数クライアントが同時に接続でき、各クライアントが PING を送信できるかを確認する。
     """
     # たまにうまくいくが、多くの場合固まる
-    num_clients = 100
+    # num_clients = 100
     # 連続して実行すると固まることがある
-    # num_clients = 10
+    num_clients = 10
     client_sockets = []
     threads = []
 


### PR DESCRIPTION
# E2Eテストについて
多数の接続をテストするE2Eテストを追加しました。
多数と言っても、まだ10件ぐらいまでしか接続できず、
それも何度も試していると固まることが判明しています。

その修正にまだ少し時間がかかりそうなので、
コンフリクトが起きる前に、一旦E2Eテストの仕組み部分だけ
プルリクを送ることにしました。

# 使用方法

E2Eテストを実行
```
make e2e_test
```