### PR TITLE
CRLFで分割してcommandHandlerに渡すように修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME := ircserv
 
 SRCS := src/main.cpp src/IRCServer.cpp src/ClientSession.cpp \
 		src/CommandHandler.cpp src/IRCMessage.cpp src/Socket.cpp \
-		src/IRCParser.cpp
+		src/IRCParser.cpp src/Utils.cpp
 OBJS := $(SRCS:.cpp=.o)
 CXXFLAGS += -I./include -Wall -Wextra -Werror -O0 -g -std=c++98 -pedantic-errors -DDEBUG
 CXX := c++

--- a/include/ClientSession.hpp
+++ b/include/ClientSession.hpp
@@ -13,8 +13,10 @@ class ClientSession {
   // std::string realName_;
   // bool registered_; // NICKとUSER登録済みか
   // std::set joinedChannels_;
+  std::string receiving_msg_;  // 受信途中のメッセージ
 
   ClientSession();
+  // ClientSessionをdeleteした時にソケットをクローズするため、コピーは許可しない
   ClientSession(const ClientSession& other);
   ClientSession& operator=(const ClientSession& other);
 
@@ -25,6 +27,9 @@ class ClientSession {
   int getFd() const;
   const std::string& getNickName() const;
   void setNickName(const std::string& nick);
+  const std::string& getReceivingMsg();
+  std::string popReceivingMsg();
+  void pushReceivingMsg(const std::string& msg);
   // void setUserInfo(const std::string& user, const std::string& real);
   // bool isRegistered() const;
 

--- a/include/IRCParser.hpp
+++ b/include/IRCParser.hpp
@@ -22,7 +22,6 @@ class IRCParser {
   // IRCParser& operator=(const IRCParser& other);
 
   // Parsing functions
-  static bool parseCrlf(IRCMessage& msg);
   static bool extractPrefix(IRCMessage& msg, std::string::size_type& pos);
   static bool extractCommand(IRCMessage& msg, std::string::size_type& pos);
   static bool extractParams(IRCMessage& msg, std::string::size_type& pos);

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -27,6 +27,8 @@ class IRCServer {
   void handleClientMessage(int clientFd);
   void disconnectClient(ClientSession* client);
 
+  static const int BUFFER_SIZE = 1024;
+
  public:
   IRCServer(const char* port, const char* password);
   ~IRCServer();

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -28,6 +28,7 @@ class IRCServer {
   void disconnectClient(ClientSession* client);
 
   static const int BUFFER_SIZE = 1024;
+  static const int MAX_MSG_SIZE = 510;  // IRCの仕様
 
  public:
   IRCServer(const char* port, const char* password);

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -24,6 +24,8 @@ class IRCServer {
   // Logger logger_;
   void acceptConnection(int listenSocketFd);
   void sendResponses(const IRCMessage& msg);
+  void handleClientMessage(int clientFd);
+  void disconnectClient(ClientSession* client);
 
  public:
   IRCServer(const char* port, const char* password);

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#ifndef __UTILS_HPP__
+#define __UTILS_HPP__
+
+#include <string>
+#include <vector>
+
+class Utils {
+ public:
+  static std::vector<std::string> split(const std::string& str,
+                                        const std::string& delimiter);
+  static bool endsWith(const std::string& str, const std::string& suffix);
+  // static bool startWith(const std::string& str, const std::string& prefix);
+
+ private:
+  Utils();
+  ~Utils();
+  Utils(const Utils& other);
+  Utils& operator=(const Utils& other);
+};
+
+#endif  // __UTILS_HPP__

--- a/src/ClientSession.cpp
+++ b/src/ClientSession.cpp
@@ -3,7 +3,8 @@
 #include <unistd.h>
 #include <iostream>
 
-ClientSession::ClientSession(int socketFd) : socket_(socketFd), nickName_("") {}
+ClientSession::ClientSession(int socketFd)
+    : socket_(socketFd), nickName_(""), receiving_msg_("") {}
 
 ClientSession::~ClientSession() {}
 
@@ -25,4 +26,18 @@ const std::string& ClientSession::getNickName() const {
 
 void ClientSession::setNickName(const std::string& nick) {
   nickName_ = nick;
+}
+
+const std::string& ClientSession::getReceivingMsg() {
+  return receiving_msg_;
+}
+
+std::string ClientSession::popReceivingMsg() {
+  std::string msg = receiving_msg_;
+  receiving_msg_.clear();
+  return msg;
+}
+
+void ClientSession::pushReceivingMsg(const std::string& msg) {
+  receiving_msg_ += msg;
 }

--- a/src/IRCParser.cpp
+++ b/src/IRCParser.cpp
@@ -3,8 +3,6 @@
 bool IRCParser::parseRaw(IRCMessage& msg) {
   std::string::size_type pos = 0;
   std::string raw = msg.getRaw();
-  // extract Crlf
-  if (!parseCrlf(msg)) return false;
   // extract prefix
   if (!extractPrefix(msg, pos)) return false;
   // extract command
@@ -14,17 +12,9 @@ bool IRCParser::parseRaw(IRCMessage& msg) {
   return true;
 }
 
-bool IRCParser::parseCrlf(IRCMessage& msg) {
-  std::string raw = msg.getRaw();
-  std::string::size_type pos = raw.find("\r\n");
-  if (pos != raw.size() - 2)
-    return false;
-  msg.setRaw(raw.substr(0, pos));
-  return true;
-}
-
 bool IRCParser::extractPrefix(IRCMessage& msg, std::string::size_type& pos) {
-  if (msg.getRaw()[pos] != ':' || pos == std::string::npos) return true;
+  if (msg.getRaw()[pos] != ':' || pos == std::string::npos)
+    return true;
   std::string raw = msg.getRaw();
   std::string prefix;
   std::string::size_type end = raw.find_first_of(" ", pos);

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -154,9 +154,10 @@ void IRCServer::handleClientMessage(int clientFd) {
     return;
   }
   // クライアントからのデータを受信した場合
-  char buffer[1024];
+  char buffer[BUFFER_SIZE];
   ssize_t bytesRead = recv(it_from->first, buffer, sizeof(buffer), 0);
-  std::string msg(buffer, bytesRead);
+  std::string msg =
+      it_from->second->popReceivingMsg() + std::string(buffer, bytesRead);
 
   if (bytesRead == 0) {
     // クライアントが切断された場合
@@ -171,8 +172,7 @@ void IRCServer::handleClientMessage(int clientFd) {
   }
   // bytesRead > 0
   // CRLFで分割して処理
-  std::vector<std::string> split_msgs =
-      Utils::split(it_from->second->popReceivingMsg() + msg, "\r\n");
+  std::vector<std::string> split_msgs = Utils::split(msg, "\r\n");
 
   // 受信途中のメッセージをセッションに退避
   if (!Utils::endsWith(msg, "\r\n")) {

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -184,7 +184,7 @@ void IRCServer::handleClientMessage(int clientFd) {
   for (std::vector<std::string>::iterator it = split_msgs.begin();
        it != split_msgs.end(); ++it) {
     // TODO msgが510(CRLFを含めて512)を超えていたら切断
-    if (it->size() > 510) {
+    if (it->size() > IRCServer::MAX_MSG_SIZE) {
       DEBUG_MSG("Message too long: " << it->size());
       disconnectClient(it_from->second);
       return;
@@ -195,7 +195,7 @@ void IRCServer::handleClientMessage(int clientFd) {
     sendResponses(msg);
   }
   // TODO receiving_msg_が510を超えていたら切断
-  if (it_from->second->getReceivingMsg().size() > 510) {
+  if (it_from->second->getReceivingMsg().size() > IRCServer::MAX_MSG_SIZE) {
     DEBUG_MSG(
         "Message too long: " << it_from->second->getReceivingMsg().size());
     disconnectClient(it_from->second);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,0 +1,29 @@
+#include "Utils.hpp"
+#include <iostream>
+
+std::vector<std::string> Utils::split(const std::string& str,
+                                      const std::string& delimiter) {
+  std::vector<std::string> ret;
+  size_t pos = 0;
+  size_t delimiter_pos = str.find(delimiter, pos);
+  while (delimiter_pos != std::string::npos) {
+    if (delimiter_pos - pos > 0) {
+      std::cout << str.substr(pos, delimiter_pos - pos) << std::endl;
+      ret.push_back(str.substr(pos, delimiter_pos - pos));
+    }
+    pos = delimiter_pos + delimiter.length();
+    delimiter_pos = str.find(delimiter, pos);
+  }
+  if (pos - str.length() > 0) {
+    ret.push_back(str.substr(pos));
+  }
+  return ret;
+}
+
+bool Utils::endsWith(const std::string& str, const std::string& suffix) {
+  if (str.length() < suffix.length()) {
+    return false;
+  }
+  return str.compare(str.length() - suffix.length(), suffix.length(), suffix) ==
+         0;
+}

--- a/test/unit/src/CommandHandler/broadCastRawMsg.cpp
+++ b/test/unit/src/CommandHandler/broadCastRawMsg.cpp
@@ -24,8 +24,8 @@ TEST(CommandHandler, broadCastRawMsg) {
   EXPECT_EQ(res.size(), 2);
 
   // 11, 12にそのままのメッセージが送信されていることを確認
-  EXPECT_EQ(res.at(clients[11]), msgStr);
-  EXPECT_EQ(res.at(clients[12]), msgStr);
+  EXPECT_EQ(res.at(clients[11]), msgStr + "\r\n");
+  EXPECT_EQ(res.at(clients[12]), msgStr + "\r\n");
   // 10には送信されていないことを確認
   EXPECT_EQ(res.find(clients[10]), res.end());
 }

--- a/test/unit/src/Utils.cpp
+++ b/test/unit/src/Utils.cpp
@@ -1,0 +1,76 @@
+#include "Utils.hpp"
+#include <gtest/gtest.h>
+
+TEST(UtilsTest, split) {
+  // ------- delimiter = "\r\n" -------------
+  {
+    std::vector<std::string> ret =
+        Utils::split("hello world\r\nabc\r\n123", "\r\n");
+
+    EXPECT_EQ(3, ret.size());
+    EXPECT_EQ("hello world", ret[0]);
+    EXPECT_EQ("abc", ret[1]);
+    EXPECT_EQ("123", ret[2]);
+  }
+  {
+    std::vector<std::string> ret = Utils::split(
+        "\r\n\r\nhello world\r\n\r\n\r\nabc\r\n\r\n123\r\n\r\n", "\r\n");
+
+    EXPECT_EQ(3, ret.size());
+    EXPECT_EQ("hello world", ret[0]);
+    EXPECT_EQ("abc", ret[1]);
+    EXPECT_EQ("123", ret[2]);
+  }
+  {
+    std::vector<std::string> ret =
+        Utils::split("hello world\rabc\n123\r\n", "\r\n");
+
+    EXPECT_EQ(1, ret.size());
+    EXPECT_EQ("hello world\rabc\n123", ret[0]);
+  }
+  // ------- delimiter = " " -------------
+  {
+    std::vector<std::string> ret = Utils::split("hello world abc 123", " ");
+
+    EXPECT_EQ(4, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world", ret[1]);
+    EXPECT_EQ("abc", ret[2]);
+    EXPECT_EQ("123", ret[3]);
+  }
+  {
+    std::vector<std::string> ret =
+        Utils::split("        hello world\r\n        abc 123           ", " ");
+
+    EXPECT_EQ(4, ret.size());
+    EXPECT_EQ("hello", ret[0]);
+    EXPECT_EQ("world\r\n", ret[1]);
+    EXPECT_EQ("abc", ret[2]);
+    EXPECT_EQ("123", ret[3]);
+  }
+}
+
+TEST(UtilsTest, endsWith) {
+  // ------- ture -------
+  {
+    bool ret = Utils::endsWith("hello world", "world");
+    EXPECT_TRUE(ret);
+  }
+  {
+    bool ret = Utils::endsWith("hello world", "d");
+    EXPECT_TRUE(ret);
+  }
+  {
+    bool ret = Utils::endsWith("hello\r\nworld\r\n", "\r\n");
+    EXPECT_TRUE(ret);
+  }
+  // ------- false -------
+  {
+    bool ret = Utils::endsWith("hello world ", "d");
+    EXPECT_FALSE(ret);
+  }
+  {
+    bool ret = Utils::endsWith("hello\r\nworld\n", "\r\n");
+    EXPECT_FALSE(ret);
+  }
+}


### PR DESCRIPTION
CRLFで分割してcommandHandlerに渡すように修正しました。

以下のようなメッセージを受信した場合は
```
1111\r\n2222\r\n3333
```

"1111"をcommandHandlerに渡し、
次に"2222"をcommandHandlerに渡します。
最後の"3333"はメッセージを受信途中の可能性があるため、
一旦ClientSessionのreceiving_msg_（受信中のメッセージ）に格納します。

次に同じクライアントから
```
aaaa\r\nbbbb\r\n
```
というメッセージを受信したら、receiving_msg_と結合して、
"3333aaaa"と"bbbb"をcommandHandlerに渡します。


