### PR TITLE
ノンブロッキングIOを実装しました

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME := ircserv
 
 SRCS := src/main.cpp src/IRCServer.cpp src/ClientSession.cpp \
 		src/CommandHandler.cpp src/IRCMessage.cpp src/Socket.cpp \
-		src/IRCParser.cpp src/Utils.cpp
+		src/IRCParser.cpp src/Utils.cpp src/IOWrapper.cpp
 OBJS := $(SRCS:.cpp=.o)
 CXXFLAGS += -I./include -Wall -Wextra -Werror -O0 -g -std=c++98 -pedantic-errors -DDEBUG
 ifdef PROD_FLG

--- a/include/ClientSession.hpp
+++ b/include/ClientSession.hpp
@@ -14,6 +14,7 @@ class ClientSession {
   // bool registered_; // NICKとUSER登録済みか
   // std::set joinedChannels_;
   std::string receiving_msg_;  // 受信途中のメッセージ
+  std::string sending_msg_;    // 送信途中のメッセージ
 
   ClientSession();
   // ClientSessionをdeleteした時にソケットをクローズするため、コピーは許可しない
@@ -21,6 +22,8 @@ class ClientSession {
   ClientSession& operator=(const ClientSession& other);
 
  public:
+  static const int kMaxSendingMsgSize = 512 * 100;  // 送信バッファサイズ
+
   ClientSession(int socketFd);
   ~ClientSession();
 
@@ -30,13 +33,15 @@ class ClientSession {
   const std::string& getReceivingMsg();
   std::string popReceivingMsg();
   void pushReceivingMsg(const std::string& msg);
+  const std::string& getSendingMsg();
+  size_t consumeSendingMsg(size_t size);
+  void pushSendingMsg(const std::string& msg);
   // void setUserInfo(const std::string& user, const std::string& real);
   // bool isRegistered() const;
 
   // void joinChannel(Channel* channel);
   // void partChannel(Channel* channel);
   // const std::set& getChannels() const;
-  void sendMessage(const std::string& message);
 };
 
 #endif  // __CLIENT_SESSION_HPP__

--- a/include/IOWrapper.hpp
+++ b/include/IOWrapper.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#ifndef __I_O_WRAPPER_HPP__
+#define __I_O_WRAPPER_HPP__
+
+#include <stdint.h>
+#include <set>
+#include "ClientSession.hpp"
+
+typedef struct epoll_event io_event;
+
+class IOWrapper {
+ public:
+  static const int kEpollMaxEvents = 10000;
+
+  IOWrapper();
+  ~IOWrapper();
+
+  bool add_monitoring(int fd, uint32_t events);
+  bool modify_monitoring(int fd, uint32_t events);
+  bool remove_monitoring(int fd);
+  int wait_monitoring(io_event* events);
+
+  bool sendMessage(ClientSession* client, const std::string& msg);
+  bool sendMessage(ClientSession* client);
+
+  static bool setNonBlockingFlag(int fd);
+
+ private:
+  int epfd_;                         // epollのファイルディスクリプタ
+  std::set<int> pending_write_fds_;  // 書き込み待ちFDのセット
+
+  IOWrapper(const IOWrapper& other);
+  IOWrapper& operator=(const IOWrapper& other);
+};
+
+#endif  // __I_O_WRAPPER_HPP__

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -6,13 +6,14 @@
 #include <string>
 
 #include "ClientSession.hpp"
+#include "IOWrapper.hpp"
 #include "IRCMessage.hpp"
 #include "IRCParser.hpp"
 #include "Socket.hpp"
 
 class IRCServer {
  private:
-  int epfd_;  // epollのファイルディスクリプタ
+  IOWrapper io_;
   std::string port_;
   std::string password_;
   std::map<int, Socket*> listenSockets_;   // ソケットFD→listeningソケット
@@ -23,13 +24,13 @@ class IRCServer {
   void acceptConnection(int listenSocketFd);
   void sendResponses(const IRCMessage& msg);
   void handleClientMessage(int clientFd);
+  void resendClientMessage(int clientFd);
   void disconnectClient(ClientSession* client);
 
   static const int BUFFER_SIZE = 1024;
   static const int MAX_MSG_SIZE = 510;  // IRCの仕様
 
   static const int MAX_BACKLOG = 100;
-  static const int EPOLL_MAX_EVENTS = 10000;
 
  public:
   IRCServer(const char* port, const char* password);

--- a/src/ClientSession.cpp
+++ b/src/ClientSession.cpp
@@ -1,20 +1,14 @@
 #include "ClientSession.hpp"
+#include <errno.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <iostream>
+#include "IRCLogger.hpp"
 
 ClientSession::ClientSession(int socketFd)
     : socket_(socketFd), nickName_(""), receiving_msg_("") {}
 
 ClientSession::~ClientSession() {}
-
-void ClientSession::sendMessage(const std::string& msg) {
-  if (send(socket_.getFd(), msg.c_str(), msg.size(), 0) == -1) {
-    std::cerr << "send failed. fd: " << socket_.getFd()
-              << ", nick: " << nickName_ << std::endl;
-    throw std::runtime_error("send failed");
-  }
-}
 
 int ClientSession::getFd() const {
   return socket_.getFd();
@@ -40,4 +34,21 @@ std::string ClientSession::popReceivingMsg() {
 
 void ClientSession::pushReceivingMsg(const std::string& msg) {
   receiving_msg_ += msg;
+}
+
+const std::string& ClientSession::getSendingMsg() {
+  return sending_msg_;
+}
+
+size_t ClientSession::consumeSendingMsg(size_t size) {
+  if (size > sending_msg_.size()) {
+    sending_msg_.clear();
+  } else {
+    sending_msg_.erase(0, size);
+  }
+  return sending_msg_.size();
+}
+
+void ClientSession::pushSendingMsg(const std::string& msg) {
+  sending_msg_ += msg;
 }

--- a/src/IOWrapper.cpp
+++ b/src/IOWrapper.cpp
@@ -1,0 +1,112 @@
+#include "IOWrapper.hpp"
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <cstdlib>
+#include <iostream>
+#include "IRCLogger.hpp"
+
+IOWrapper::IOWrapper() {
+  epfd_ = epoll_create1(EPOLL_CLOEXEC);
+  if (epfd_ == -1) {
+    std::cerr << "epoll_create failed\n";
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+IOWrapper::~IOWrapper() {
+  if (close(epfd_) == -1) {
+    std::cerr << "close failed" << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+}
+
+bool IOWrapper::add_monitoring(int fd, uint32_t events) {
+  struct epoll_event ev;
+  ev.events = events;
+  ev.data.fd = fd;
+  if (epoll_ctl(epfd_, EPOLL_CTL_ADD, fd, &ev) == -1) {
+    std::cerr << "epoll_ctl failed" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+bool IOWrapper::modify_monitoring(int fd, uint32_t events) {
+  struct epoll_event ev;
+  ev.events = events;
+  ev.data.fd = fd;
+  if (epoll_ctl(epfd_, EPOLL_CTL_MOD, fd, &ev) == -1) {
+    std::cerr << "epoll_ctl failed" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+bool IOWrapper::remove_monitoring(int fd) {
+  if (epoll_ctl(epfd_, EPOLL_CTL_DEL, fd, NULL) == -1) {
+    std::cerr << "epoll_ctl failed" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+int IOWrapper::wait_monitoring(epoll_event* events) {
+  return epoll_wait(epfd_, events, kEpollMaxEvents, -1);
+}
+
+bool IOWrapper::sendMessage(ClientSession* client, const std::string& msg) {
+  client->pushSendingMsg(msg);
+  if (client->getSendingMsg().size() > ClientSession::kMaxSendingMsgSize) {
+    std::cerr << "Sending message size exceeds limit: "
+              << client->getSendingMsg().size() << std::endl;
+    return false;
+  }
+  return sendMessage(client);
+}
+
+bool IOWrapper::sendMessage(ClientSession* client) {
+  size_t msg_size = client->getSendingMsg().size();
+  if (msg_size == 0) {
+    // 送信するメッセージがない場合は何もしない
+    return true;
+  }
+  while (msg_size > 0) {
+    ssize_t bytes_sent = send(client->getFd(), client->getSendingMsg().c_str(),
+                              client->getSendingMsg().size(), 0);
+    if (bytes_sent >= 0) {
+      // 送信したバイト数を送信待ちメッセージから削除
+      msg_size = client->consumeSendingMsg(bytes_sent);
+      continue;
+    } else {
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        // 一時的に書き込みがブロックされているため、EPOLL書き込み可能になるまで監視
+        modify_monitoring(client->getFd(), EPOLLIN | EPOLLOUT | EPOLLET);
+        pending_write_fds_.insert(client->getFd());
+        return true;
+      } else {
+        std::cerr << "send failed. fd: " << client->getFd() << std::endl;
+        return false;
+      }
+    }
+  }
+  // すべてのメッセージが送信された場合
+  if (pending_write_fds_.find(client->getFd()) != pending_write_fds_.end()) {
+    modify_monitoring(client->getFd(), EPOLLIN | EPOLLET);
+    pending_write_fds_.erase(client->getFd());
+  }
+  return true;
+}
+
+bool IOWrapper::setNonBlockingFlag(int fd) {
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (flags == -1) {
+    return false;
+  }
+  if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
+    return false;
+  }
+  return true;
+}

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -8,7 +8,6 @@ std::vector<std::string> Utils::split(const std::string& str,
   size_t delimiter_pos = str.find(delimiter, pos);
   while (delimiter_pos != std::string::npos) {
     if (delimiter_pos - pos > 0) {
-      std::cout << str.substr(pos, delimiter_pos - pos) << std::endl;
       ret.push_back(str.substr(pos, delimiter_pos - pos));
     }
     pos = delimiter_pos + delimiter.length();

--- a/test/e2e/many_clients_test.py
+++ b/test/e2e/many_clients_test.py
@@ -88,50 +88,42 @@ def test_many_clients():
         s.close()
 
 
-# def test_many_clients_with_hanging():
-#     """
-#     ハングしているクライアントが含まれている場合
-#     """
-#     num_clients = 10
-#     client_sockets = []
-#     hanging_sockets = []
-#     threads = []
+def test_hanging_client():
+    """
+    ハングしているクライアントが含まれている場合
+    """
+    num_clients = 10000
+    client_sockets = []
+    hanging_sockets = []
+    threads = []
 
-#     def client_worker(index):
-#         try:
-#             if index % 3 == 0:
-#                 s = connect_client(is_send_msg=False, is_hang=True)
-#                 hanging_sockets.append(s)
-#             elif index % 3 == 1:
-#                 s = connect_client(is_send_msg=True, is_hang=True)
-#                 hanging_sockets.append(s)
-#             else:
-#                 s = connect_client(is_send_msg=True, is_hang=False)
-#                 client_sockets.append(s)
-#         except Exception as e:
-#             pytest.fail(f"Client {index} failed to connect: {e}")
+    def client_worker(index):
+        try:
+            if index % 3 == 0:
+                s = connect_client(is_send_msg=False, is_hang=True)
+                hanging_sockets.append(s)
+            elif index % 3 == 1:
+                s = connect_client(is_send_msg=True, is_hang=True)
+                hanging_sockets.append(s)
+            else:
+                s = connect_client(is_send_msg=True, is_hang=False)
+                client_sockets.append(s)
+        except Exception as e:
+            pytest.fail(f"Client {index} failed to connect: {e}")
 
-#     for i in range(num_clients):
-#         t = threading.Thread(target=client_worker, args=(i,))
-#         threads.append(t)
-#         t.start()
-#     for t in threads:
-#         t.join()
+    for i in range(num_clients):
+        t = threading.Thread(target=client_worker, args=(i,))
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
 
-#     assert (
-#         len(client_sockets) + len(hanging_sockets)
-#     ) == num_clients, "全てのクライアントが接続できなかった"
+    assert (
+        len(client_sockets) + len(hanging_sockets)
+    ) == num_clients, "全てのクライアントが接続できなかった"
 
-#     try:
-#         for s in client_sockets:
-#             data = "aaa"
-#             # data = s.recv(1024)
-#             # assert data == b"PONG\r\n", f"クライアントからの応答が不正: {data}"
-#             assert len(data) > 0, "正常なクライアントの応答が空"
-#     except Exception as e:
-#         pytest.fail(f"正常なクライアントの受信に失敗: {e}")
-#     finally:
-#         for s in client_sockets:
-#             s.close()
-#         for s in hanging_sockets:
-#             s.close()
+
+    for s in client_sockets:
+        s.close()
+    for s in hanging_sockets:
+        s.close()


### PR DESCRIPTION
クライアントへのメッセージ送信をノンブロッキングIOに対応しました。
ログ、エラー出力はまだ未対応です。
コードの修正量が大きくなったので一旦プルリク送ります。

src/IOWrapper.cppのここがFDに対して、ノンブロッキングを指定する関数になります。
```
bool IOWrapper::setNonBlockingFlag(int fd) {
  int flags = fcntl(fd, F_GETFL, 0);
  if (flags == -1) {
    return false;
  }
  if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
    return false;
  }
  return true;
}
```

ノンブロッキングの場合、send（write）を呼んだ時にノンブロッキング特有のエラーがerrnoに設定されます。
src/IOWrapper.cppのここでノンブロッキングで一時的に書き込めなかったかどうか判定して、
Epollで書き込み可能になるまでそのソケットを監視対象に追加しています。
```
      if (errno == EAGAIN || errno == EWOULDBLOCK) {
        // ノンブロッキングIOにより一時的に書き込みがブロックされているため、
        // EPOLLで書き込み可能になるまで監視
        modify_monitoring(client->getFd(), EPOLLIN | EPOLLOUT | EPOLLET);
        pending_write_fds_.insert(client->getFd());
        return true;
      } else {
```
書き込み可能になったらメッセージを再送します。


メッセージが送信できない可能性があるため、
ClientSessionに送信待ちメッセージのキューを追加しました。
```
  std::string sending_msg_;    // 送信途中のメッセージ
```
sending_msg_に無限にデータがたまるのを防ぐため、
下記で上限値を設定していますが、この上限値は適当に決めただけです。
上限を超えたらそのクライアントは切断します。
```
  static const int kMaxSendingMsgSize = 512 * 100;  // 送信バッファサイズ
```


