### PR TITLE
ログ出力をノンブロッキングに対応しました

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ NAME := ircserv
 
 SRCS := src/main.cpp src/IRCServer.cpp src/ClientSession.cpp \
 		src/CommandHandler.cpp src/IRCMessage.cpp src/Socket.cpp \
-		src/IRCParser.cpp src/Utils.cpp src/IOWrapper.cpp
+		src/IRCParser.cpp src/Utils.cpp src/IOWrapper.cpp src/IRCLogger.cpp
 OBJS := $(SRCS:.cpp=.o)
 CXXFLAGS += -I./include -Wall -Wextra -Werror -O0 -g -std=c++98 -pedantic-errors -DDEBUG
 ifdef PROD_FLG
@@ -37,7 +37,6 @@ unit_test:
 
 .PHONY: e2e_test
 e2e_test:
-	$(MAKE) re PROD_FLG=1
 	cd test/e2e \
 	&& pytest -vs
 

--- a/include/IOWrapper.hpp
+++ b/include/IOWrapper.hpp
@@ -23,6 +23,8 @@ class IOWrapper {
   bool sendMessage(ClientSession* client, const std::string& msg);
   bool sendMessage(ClientSession* client);
 
+  bool writeLog();
+
   static bool setNonBlockingFlag(int fd);
 
  private:

--- a/include/IRCLogger.hpp
+++ b/include/IRCLogger.hpp
@@ -3,16 +3,52 @@
 #define __IRC_LOGGER_HPP__
 
 #include <iostream>
+#include <sstream>
 
 #ifdef DEBUG
-#define DEBUG_MSG(msg)                          \
-  do {                                          \
-    std::cerr << "DEBUG: " << msg << std::endl; \
+#define DEBUG_MSG(msg)                                         \
+  do {                                                         \
+    IRCLogger::getInstance() << "DEBUG: " << msg << std::endl; \
   } while (0)
 #else
 #define DEBUG_MSG(msg) \
   do {                 \
   } while (0)
 #endif
+
+class IRCLogger {
+ public:
+  // シングルトン
+  static IRCLogger& getInstance();
+
+  const std::string& getLog() const;
+  int getFd() const;
+  size_t consumeLog(size_t size);
+
+  template <typename T>
+  IRCLogger& operator<<(const T& value) {
+    std::ostringstream oss;
+    oss << value;
+    log_ += oss.str();
+    return *this;
+  }
+
+  IRCLogger& operator<<(std::ostream& (*manip)(std::ostream&)) {
+    std::ostringstream oss;
+    oss << manip;
+    log_ += oss.str();
+
+    return *this;
+  }
+
+ private:
+  std::string log_;
+  int fd_;
+
+  IRCLogger();
+  ~IRCLogger();
+  IRCLogger(const IRCLogger& other);
+  IRCLogger& operator=(const IRCLogger& other);
+};
 
 #endif  // __IRC_LOGGER_HPP__

--- a/src/IOWrapper.cpp
+++ b/src/IOWrapper.cpp
@@ -82,7 +82,8 @@ bool IOWrapper::sendMessage(ClientSession* client) {
       continue;
     } else {
       if (errno == EAGAIN || errno == EWOULDBLOCK) {
-        // 一時的に書き込みがブロックされているため、EPOLL書き込み可能になるまで監視
+        // ノンブロッキングIOにより一時的に書き込みがブロックされているため、
+        // EPOLLで書き込み可能になるまで監視
         modify_monitoring(client->getFd(), EPOLLIN | EPOLLOUT | EPOLLET);
         pending_write_fds_.insert(client->getFd());
         return true;

--- a/src/IRCLogger.cpp
+++ b/src/IRCLogger.cpp
@@ -1,0 +1,38 @@
+
+
+#include "IRCLogger.hpp"
+#include <unistd.h>
+#include <iostream>
+#include "IOWrapper.hpp"
+
+IRCLogger& IRCLogger::getInstance() {
+  static IRCLogger instance;
+  return instance;
+}
+
+IRCLogger::IRCLogger() {
+  log_ = "";
+  fd_ = STDERR_FILENO;
+  if (!IOWrapper::setNonBlockingFlag(fd_)) {
+    throw std::runtime_error("fcntl: set non-blocking flag failed");
+  }
+}
+
+IRCLogger::~IRCLogger() {}
+
+const std::string& IRCLogger::getLog() const {
+  return log_;
+}
+
+int IRCLogger::getFd() const {
+  return fd_;
+}
+
+size_t IRCLogger::consumeLog(size_t size) {
+  if (size > log_.size()) {
+    log_.clear();
+    return 0;
+  }
+  log_.erase(0, size);
+  return log_.size();
+}

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -113,14 +113,6 @@ void IRCServer::acceptConnection(int listenSocketFd) {
   int sockfd = accept(listenSocketFd, (struct sockaddr*)&addr, &addrlen);
   addClient(new ClientSession(sockfd));
 
-  // ソケットをノンブロッキングに設定
-  if (!IOWrapper::setNonBlockingFlag(sockfd)) {
-    std::cerr << "fcntl: set non-blocking flag failed: fd" << sockfd
-              << std::endl;
-    close(sockfd);
-    return;
-  }
-
   // クライアントのソケットを監視対象に追加
   if (!io_.add_monitoring(sockfd, EPOLLIN | EPOLLET)) {
     close(sockfd);

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -235,9 +235,9 @@ void IRCServer::run() {
     for (int j = 0; j < ready; j++) {
       if (evlist[j].events & EPOLLIN) {
         // イベントが発生したソケットに対して処理を行う
-        if (listenSockets_.count(evlist[0].data.fd) > 0) {
+        if (listenSockets_.count(evlist[j].data.fd) > 0) {
           // 新しい接続を受け入れる
-          acceptConnection(evlist[0].data.fd);
+          acceptConnection(evlist[j].data.fd);
         }
         handleClientMessage(evlist[j].data.fd);
       } else if (evlist[j].events & EPOLLOUT) {

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -27,6 +27,13 @@ IRCServer::IRCServer(const char* port, const char* password) {
 
   password_ = std::string(password);
 
+  // ログ出力をノンブロッキングに設定
+  if (!io_.modify_monitoring(IRCLogger::getInstance().getFd(),
+                             EPOLLIN | EPOLLET)) {
+    std::cerr << "Error: modify_monitoring failed" << std::endl;
+    std::exit(EXIT_FAILURE);
+  }
+
   DEBUG_MSG("Port: " << port_ << ", Password: " << password_);
 }
 
@@ -211,8 +218,6 @@ void IRCServer::resendClientMessage(int clientFd) {
 }
 
 void IRCServer::run() {
-  io_.modify_monitoring(IRCLogger::getInstance().getFd(), EPOLLIN | EPOLLET);
-
   while (true) {
     io_event evlist[IOWrapper::kEpollMaxEvents];
     // TODO ログ書き出し

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -1,11 +1,18 @@
 #include "Socket.hpp"
 #include <unistd.h>
 #include <iostream>
+#include "IOWrapper.hpp"
 #include "IRCLogger.hpp"
 
 Socket::Socket(int fd) : fd_(fd) {
   if (fd_ < 0) {
     throw std::runtime_error("socket(2) failed");
+  }
+  // ソケットをノンブロッキングに設定
+  if (!IOWrapper::setNonBlockingFlag(fd_)) {
+    std::cerr << "fcntl: set non-blocking flag failed: fd" << fd_ << std::endl;
+    close(fd_);
+    throw std::runtime_error("fcntl: set non-blocking flag failed");
   }
   DEBUG_MSG("Socket created fd: " << fd_);
 }


### PR DESCRIPTION
ログ出力をノンブロッキングに対応しました。
本当はエラーログの所、
```
std::cerr << ...
```
をノンブロッキングに対応したいのですが、
まだデバッグログ（DEBUG_LOG()の所）しか対応できていません。

そこは別のプルリクで修正します。
