### PR TITLE
単体テストのエラー修正

### DIFF
--- a/src/IOWrapper.cpp
+++ b/src/IOWrapper.cpp
@@ -24,6 +24,7 @@ IOWrapper::~IOWrapper() {
 }
 
 bool IOWrapper::add_monitoring(int fd, uint32_t events) {
+#ifndef UNIT_TEST
   struct epoll_event ev;
   ev.events = events;
   ev.data.fd = fd;
@@ -31,10 +32,12 @@ bool IOWrapper::add_monitoring(int fd, uint32_t events) {
     std::cerr << "epoll_ctl failed" << std::endl;
     return false;
   }
+#endif
   return true;
 }
 
 bool IOWrapper::modify_monitoring(int fd, uint32_t events) {
+#ifndef UNIT_TEST
   struct epoll_event ev;
   ev.events = events;
   ev.data.fd = fd;
@@ -42,14 +45,17 @@ bool IOWrapper::modify_monitoring(int fd, uint32_t events) {
     std::cerr << "epoll_ctl failed" << std::endl;
     return false;
   }
+#endif
   return true;
 }
 
 bool IOWrapper::remove_monitoring(int fd) {
+#ifndef UNIT_TEST
   if (epoll_ctl(epfd_, EPOLL_CTL_DEL, fd, NULL) == -1) {
     std::cerr << "epoll_ctl failed" << std::endl;
     return false;
   }
+#endif
   return true;
 }
 
@@ -136,6 +142,7 @@ bool IOWrapper::writeLog() {
 }
 
 bool IOWrapper::setNonBlockingFlag(int fd) {
+#ifndef UNIT_TEST
   int flags = fcntl(fd, F_GETFL, 0);
   if (flags == -1) {
     return false;
@@ -143,5 +150,6 @@ bool IOWrapper::setNonBlockingFlag(int fd) {
   if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
     return false;
   }
+#endif
   return true;
 }

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -28,7 +28,7 @@ IRCServer::IRCServer(const char* port, const char* password) {
   password_ = std::string(password);
 
   // ログ出力をノンブロッキングに設定
-  if (!io_.modify_monitoring(IRCLogger::getInstance().getFd(),
+  if (!io_.add_monitoring(IRCLogger::getInstance().getFd(),
                              EPOLLIN | EPOLLET)) {
     std::cerr << "Error: modify_monitoring failed" << std::endl;
     std::exit(EXIT_FAILURE);

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(libftirc ${LIB_SRCS})
 
 target_compile_definitions(libftirc PRIVATE UNIT_TEST)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -DUNIT_TEST=1")
 include_directories(
   "${CMAKE_CURRENT_SOURCE_DIR}/../../include"
   # "${CMAKE_CURRENT_SOURCE_DIR}/build/_deps/googletest-src/googletest/include"


### PR DESCRIPTION
ノンブロッキングIOにしたことで単体テストがエラーになっていたので、
単体テストではノンブロッキングに設定しないように修正