### PR TITLE
Channelクラスの作成とコマンドの実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME := ircserv
 
-SRCS := src/main.cpp src/IRCServer.cpp src/Client.cpp \
+SRCS := src/main.cpp src/IRCServer.cpp src/Client.cpp src/Channel.cpp\
 		src/CommandHandler.cpp src/IRCMessage.cpp src/Socket.cpp \
 		src/IRCParser.cpp src/Utils.cpp src/IOWrapper.cpp src/IRCLogger.cpp
 OBJS := $(SRCS:.cpp=.o)

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -12,7 +12,7 @@ class Client;
 class Channel {
  private:
   // Member variables
-  std::string name_;
+  std::string const name_;
   std::string topic_;
   std::string password_;
   bool isInviteOnly_;
@@ -40,7 +40,6 @@ class Channel {
   bool isInvited(Client* client) const;
 
   // Setters
-  bool setName(const std::string& name);
   bool setTopic(const std::string& topic);
   bool setPassword(const std::string& password);
   bool setInviteOnly(bool isInviteOnly);

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -1,0 +1,56 @@
+#pragma once
+#ifndef __CHANNEL_HPP__
+#define __CHANNEL_HPP__
+
+#include <set>
+#include <string>
+
+#include "Client.hpp"
+
+class Client;
+
+class Channel {
+ private:
+  // Member variables
+  std::string name_;
+  std::string topic_;
+  std::string password_;
+  bool isInviteOnly_;
+  std::set<Client*> member_;
+  std::set<Client*> chanop_;
+  std::set<Client*> invited_;
+
+ public:
+  // Orthodox Cannonical Form
+  // Channel();
+  ~Channel();
+  // Channel(const Channel& other);
+  // Channel& operator=(const Channel& other);
+  Channel(const std::string& name, Client* client);
+
+  // Getters
+  const std::string& getName() const;
+  const std::string& getTopic() const;
+  bool isInviteOnly() const;
+  const std::set<Client*>& getMember() const;
+  const std::set<Client*>& getChanop() const;
+  const std::set<Client*>& getInvited() const;
+  bool isMember(Client* client) const;
+  bool isChanop(Client* client) const;
+  bool isInvited(Client* client) const;
+
+  // Setters
+  bool setName(const std::string& name);
+  bool setTopic(const std::string& topic);
+  bool setPassword(const std::string& password);
+  bool setInviteOnly(bool isInviteOnly);
+  bool addMember(Client* client);
+  bool addChanop(Client* client);
+  bool addInvited(Client* client);
+  bool removeMember(Client* client);
+  bool removeChanop(Client* client);
+  bool removeInvited(Client* client);
+
+};
+
+#endif

--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -3,43 +3,62 @@
 #define __CLIENT_SESSION_HPP__
 
 #include <string>
+#include <vector>
 
+#include "Channel.hpp"
 #include "Socket.hpp"
+
+class Channel;
 
 class Client {
  private:
+  // Member variables
   Socket socket_;
   std::string nickName_;
-  // std::string userName_;
-  // std::string realName_;
-  // bool registered_; // NICKとUSER登録済みか
-  // std::set joinedChannels_;
+  std::string userName_;
+  std::string realName_;
+  std::string password_;
+  // bool isRegistered_; // NICKとUSER登録済みか
+  std::vector<Channel*> joinedChannels_;
   std::string receiving_msg_;  // 受信途中のメッセージ
   std::string sending_msg_;    // 送信途中のメッセージ
-
-  Client();
-  // Clientをdeleteした時にソケットをクローズするため、コピーは許可しない
-  Client(const Client& other);
-  Client& operator=(const Client& other);
-
- public:
+  
+  public:
   static const int kMaxSendingMsgSize = 512 * 100;  // 送信バッファサイズ
-
-  Client(int socketFd);
+  
+  // Constructor & Destructor
+  // Client();
   ~Client();
+  Client(int socketFd);
+  // // Clientをdeleteした時にソケットをクローズするため、コピーは許可しない
+  // Client(const Client& other);
+  // Client& operator=(const Client& other);
 
+  // Getters
   int getFd() const;
   const std::string& getNickName() const;
-  void setNickName(const std::string& nick);
-  const std::string& getReceivingMsg();
+  const std::string& getUserName() const;
+  const std::string& getRealName() const;
+  const std::string& getPassword() const;
+  // const bool& getIsRegistrated() const;
+  const std::string& getReceivingMsg() const;
+
+  // Setters
+  void setNickName(const std::string& name);
+  void setUserName(const std::string& name);
+  void setRealName(const std::string& name);
+  void setPassword(const std::string& pass);
+  // void setIsRegisterd(const bool isRegisterd);
+
+  // Member functions
   std::string popReceivingMsg();
   void pushReceivingMsg(const std::string& msg);
   const std::string& getSendingMsg();
   size_t consumeSendingMsg(size_t size);
   void pushSendingMsg(const std::string& msg);
+  void sendMessage(const std::string& msg);
   // void setUserInfo(const std::string& user, const std::string& real);
   // bool isRegistered() const;
-
   // void joinChannel(Channel* channel);
   // void partChannel(Channel* channel);
   // const std::set& getChannels() const;

--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -19,20 +19,22 @@ class Client {
   std::string realName_;
   std::string password_;
   // bool isRegistered_; // NICKとUSER登録済みか
-  std::vector<Channel*> joinedChannels_;
+  // std::map<std::string, Channel*> joinedChannels_;
   std::string receiving_msg_;  // 受信途中のメッセージ
   std::string sending_msg_;    // 送信途中のメッセージ
-  
+
+  // Constractor & Destructor
+  Client();
+  // // Clientをdeleteした時にソケットをクローズするため、コピーは許可しない
+  Client(const Client& other);
+  Client& operator=(const Client& other);
+
   public:
   static const int kMaxSendingMsgSize = 512 * 100;  // 送信バッファサイズ
-  
+
   // Constructor & Destructor
-  // Client();
   ~Client();
   Client(int socketFd);
-  // // Clientをdeleteした時にソケットをクローズするため、コピーは許可しない
-  // Client(const Client& other);
-  // Client& operator=(const Client& other);
 
   // Getters
   int getFd() const;

--- a/include/CommandHandler.hpp
+++ b/include/CommandHandler.hpp
@@ -6,29 +6,38 @@
 
 #include "IRCMessage.hpp"
 #include "IRCServer.hpp"
+#include "IRCLogger.hpp"
 
 class CommandHandler {
  private:
+  // Member variables
   IRCServer* server_;
-
- private:
-  // void handleUser(Client* client, const IRCMessage& message);
-  // void handleJoin(Client* client, const IRCMessage& message);
-  // void handlePrivmsg(Client* client, const IRCMessage& message);
-  // void handlePart(Client* client, const IRCMessage& message);
-  // void handleQuit(Client* client, const IRCMessage& message);
-  // void handlePong(Client* client, const IRCMessage& message);
+  // IRCMessage msg_;
+  std::map<Client*, std::string> responses_;
+  
+  // Handle commands
+  void Pass(const IRCMessage& msg);
+  void Nick(const IRCMessage& msg);
+  void User(const IRCMessage& msg);
+  void Join(const IRCMessage& msg);
+  // void Privmsg(const IRCMessage& msg);
+  // void Part(const IRCMessage& msg);
+  // void Quit(const IRCMessage& msg);
+  void Ping(IRCMessage& msg);
+  // void handlePong(IRCMessage& msg);
 
  public:
+  // Orthodox Canonical Form
+  // CommandHandler();
   CommandHandler(IRCServer* server);
   ~CommandHandler();
   CommandHandler(const CommandHandler& other);
   CommandHandler& operator=(const CommandHandler& other);
 
+  // Member functions
   const std::map<Client*, std::string>& handleCommand(IRCMessage& msg);
   const std::map<Client*, std::string>& broadCastRawMsg(IRCMessage& msg);
-  const std::map<Client*, std::string>& handleNick(IRCMessage& msg);
-  const std::map<Client*, std::string>& handlePing(IRCMessage& msg);
+  // const std::map<Client*, std::string>& handlePing(IRCMessage& msg);
 };
 
 #endif  // __COMMAND_HANDLER_HPP__

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <string>
 
+#include "Channel.hpp"
 #include "Client.hpp"
 #include "IOWrapper.hpp"
 #include "IRCMessage.hpp"
@@ -13,11 +14,13 @@
 
 class IRCServer {
  private:
+  // Member variables
   IOWrapper io_;
   std::string port_;
   std::string password_;
   std::map<int, Socket*> listenSockets_;  // ソケットFD→listeningソケット
   std::map<int, Client*> clients_;        // ソケットFD→クライアント
+  std::map<std::string, Channel*> channels_;  // チャンネル名→チャンネルオブジェクト
   // UserManager userManager_;
   // ChannelManager channelManager_;
   // Logger logger_;
@@ -29,25 +32,35 @@ class IRCServer {
 
   static const int BUFFER_SIZE = 1024;
   static const int MAX_MSG_SIZE = 510;  // IRCの仕様
-
   static const int MAX_BACKLOG = 100;
 
  public:
+  // Orthodox Canonical Form
+  IRCServer();
   IRCServer(const char* port, const char* password);
   ~IRCServer();
   IRCServer(const IRCServer& other);
   IRCServer& operator=(const IRCServer& other);
 
+  // Getters
+  const std::map<int, Client*>& getClients() const;
+  const std::map<std::string, Channel*>& getChannels() const;
+  Channel* getChannel(const std::string& name) const;
+
+  // Setters
+  bool addClient(Client* client);
+  bool addChannel(const std::string& name, Client* client);
+  bool ifChannleExists(const std::string& name) const;
+  // bool removeClient(Client* client);
+  bool removeChannel(const std::string& name);
+
+  // Member functions
   void startListen();  // ソケットをバインドしてリッスン状態にする
   void run();          // メインループ。接続受付、読み書き処理
   // void acceptConnection();
   // void receiveMessage(Client* client);
   // void sendMessage(Client* client, const std::string& message);
   // void disconnectClient(Client* client);
-
-  // clients_を取得
-  const std::map<int, Client*>& getClients() const;
-  void addClient(Client* client);
 };
 
 #endif  // __IRC_SERVER_HPP__

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -1,0 +1,101 @@
+#include "Channel.hpp"
+
+Channel::~Channel() {}
+
+Channel::Channel(const std::string& name, Client* client)
+    : name_(name),
+      isInviteOnly_(false),
+      member_(std::set<Client*>()),
+      chanop_(std::set<Client*>()),
+      invited_(std::set<Client*>()) {
+  member_.insert(client);
+  chanop_.insert(client);
+}
+
+// Getters
+const std::string& Channel::getName() const {
+  return name_;
+}
+
+const std::string& Channel::getTopic() const {
+  return topic_;
+}
+
+bool Channel::isInviteOnly(void) const {
+  return isInviteOnly_;
+}
+
+const std::set<Client*>& Channel::getMember() const {
+  return member_;
+}
+
+const std::set<Client*>& Channel::getChanop() const {
+  return chanop_;
+}
+
+const std::set<Client*>& Channel::getInvited() const {
+  return invited_;
+}
+
+bool Channel::isMember(Client* client) const {
+  if (member_.find(client) != member_.end()) {
+    return true;
+  }
+  return false;
+}
+
+bool Channel::isChanop(Client* client) const {
+  if (chanop_.find(client) != chanop_.end()) {
+    return true;
+  }
+  return false;
+}
+
+bool Channel::isInvited(Client* client) const {
+  if (invited_.find(client) != invited_.end()) {
+    return true;
+  }
+  return false;
+}
+
+// Setters
+bool Channel::setName(const std::string& name) {
+  name_ = name;
+}
+
+bool Channel::setTopic(const std::string& topic) {
+  topic_ = topic;
+}
+
+bool Channel::setPassword(const std::string& password) {
+  password_ = password;
+}
+
+bool Channel::setInviteOnly(bool isInviteOnly) {
+  isInviteOnly_ = isInviteOnly;
+}
+
+bool Channel::addMember(Client* client) {
+  member_.insert(client);
+}
+
+bool Channel::addChanop(Client* client) {
+  chanop_.insert(client);
+}
+
+bool Channel::addInvited(Client* client) {
+  invited_.insert(client);
+}
+
+bool Channel::removeMember(Client* client) {
+  member_.erase(client);
+}
+
+bool Channel::removeChanop(Client* client) {
+  chanop_.erase(client);
+}
+
+bool Channel::removeInvited(Client* client) {
+  invited_.erase(client);
+}
+

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -3,11 +3,10 @@
 Channel::~Channel() {}
 
 Channel::Channel(const std::string& name, Client* client)
-    : name_(name),
-      isInviteOnly_(false),
-      member_(std::set<Client*>()),
-      chanop_(std::set<Client*>()),
-      invited_(std::set<Client*>()) {
+    : name_(name), isInviteOnly_(false)
+    , member_(std::set<Client*>())
+    , chanop_(std::set<Client*>())
+    , invited_(std::set<Client*>()) {
   member_.insert(client);
   chanop_.insert(client);
 }
@@ -59,43 +58,67 @@ bool Channel::isInvited(Client* client) const {
 }
 
 // Setters
-bool Channel::setName(const std::string& name) {
-  name_ = name;
-}
-
 bool Channel::setTopic(const std::string& topic) {
   topic_ = topic;
+  return true;
 }
 
 bool Channel::setPassword(const std::string& password) {
   password_ = password;
+  return true;
 }
 
 bool Channel::setInviteOnly(bool isInviteOnly) {
   isInviteOnly_ = isInviteOnly;
+  return true;
 }
 
 bool Channel::addMember(Client* client) {
-  member_.insert(client);
+  if (member_.find(client) != member_.end()) {
+    return true;
+  }
+  if (!isInviteOnly_ && invited_.find(client) != invited_.end()) {
+    member_.insert(client);
+    return true;
+  }
+  return false;
 }
 
 bool Channel::addChanop(Client* client) {
-  chanop_.insert(client);
+  if (member_.find(client) == member_.end()) {
+    return false;
+  }
+  if (chanop_.find(client) != chanop_.end()) {
+    return true;
+  }
+  return false;
 }
 
 bool Channel::addInvited(Client* client) {
   invited_.insert(client);
+  return true;
 }
 
 bool Channel::removeMember(Client* client) {
-  member_.erase(client);
+  if (member_.find(client) == member_.end()) {
+    member_.erase(client);
+    return true;
+  }
+  return false;
 }
 
 bool Channel::removeChanop(Client* client) {
-  chanop_.erase(client);
+  if (chanop_.find(client) == chanop_.end()) {
+    chanop_.erase(client);
+    return true;
+  }
+  return false;
 }
 
 bool Channel::removeInvited(Client* client) {
-  invited_.erase(client);
+  if (invited_.find(client) == invited_.end()) {
+    invited_.erase(client);
+    return true;
+  }
+  return false;
 }
-

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -3,33 +3,68 @@
 #include <errno.h>
 #include <sys/socket.h>
 #include <unistd.h>
-
 #include <iostream>
 
 #include "IRCLogger.hpp"
 
+// Constructor & Destructor
 Client::Client(int socketFd)
     : socket_(socketFd), nickName_(""), receiving_msg_("") {}
 
 Client::~Client() {}
 
-int Client::getFd() const { return socket_.getFd(); }
+// Getters
+int Client::getFd() const {
+  return socket_.getFd();
+}
 
-const std::string& Client::getNickName() const { return nickName_; }
+const std::string& Client::getNickName() const {
+  return nickName_;
+}
 
-void Client::setNickName(const std::string& nick) { nickName_ = nick; }
+const std::string& Client::getUserName() const {
+  return userName_;
+}
 
-const std::string& Client::getReceivingMsg() { return receiving_msg_; }
+const std::string& Client::getRealName() const {
+  return realName_;
+}
 
+const std::string& Client::getPassword() const {
+  return password_;
+}
+
+const std::string& Client::getReceivingMsg() const {
+  return receiving_msg_;
+}
+
+// Setters
+void Client::setNickName(const std::string& nick) {
+  nickName_ = nick;
+}
+
+void Client::setUserName(const std::string& user) {
+  userName_ = user;
+}
+
+void Client::setRealName(const std::string& real) {
+  realName_ = real;
+}
+
+void Client::setPassword(const std::string& pass) {
+  password_ = pass;
+}
+
+// Member Functions
 std::string Client::popReceivingMsg() {
   std::string msg = receiving_msg_;
   receiving_msg_.clear();
   return msg;
 }
 
-void Client::pushReceivingMsg(const std::string& msg) { receiving_msg_ += msg; }
-
-const std::string& Client::getSendingMsg() { return sending_msg_; }
+const std::string& Client::getSendingMsg() {
+  return sending_msg_;
+}
 
 size_t Client::consumeSendingMsg(size_t size) {
   if (size > sending_msg_.size()) {
@@ -40,4 +75,18 @@ size_t Client::consumeSendingMsg(size_t size) {
   return sending_msg_.size();
 }
 
-void Client::pushSendingMsg(const std::string& msg) { sending_msg_ += msg; }
+void Client::pushSendingMsg(const std::string& msg) {
+  sending_msg_ += msg;
+}
+
+void Client::pushReceivingMsg(const std::string& msg) {
+  receiving_msg_ += msg;
+}  
+
+void Client::sendMessage(const std::string& msg) {
+  if (send(socket_.getFd(), msg.c_str(), msg.size(), 0) == -1) {
+    std::cerr << "send failed. fd: " << socket_.getFd()
+              << ", nick: " << nickName_ << std::endl;
+    throw std::runtime_error("send failed");
+  }
+}

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -17,7 +17,7 @@ CommandHandler& CommandHandler::operator=(const CommandHandler& other) {
   }
   server_ = other.server_;
   return *this;
-}  
+}
 
 // Member functions
 const std::map<Client*, std::string>& CommandHandler::handleCommand(IRCMessage& msg) {
@@ -35,6 +35,7 @@ const std::map<Client*, std::string>& CommandHandler::handleCommand(IRCMessage& 
   );
 
   // コマンドごとに処理を分岐
+  // TODO: switch文など、もっと簡単に書けそう
   std::string command = msg.getCommand();
   DEBUG_MSG("Command: " << command);
   if (command == "NICK")
@@ -43,11 +44,11 @@ const std::map<Client*, std::string>& CommandHandler::handleCommand(IRCMessage& 
     User(msg);
   // else if (command == "JOIN")
   //   Join(msg);
-  // else if (command == "PRIVMSG")  
+  // else if (command == "PRIVMSG")
   //   Privmsg(msg);
   // else if (command == "PART")
   //   Part(msg);
-  // else if (command == "QUIT")  
+  // else if (command == "QUIT")
   //   Quit(msg);
   else if (command == "PING")
     Ping(msg);
@@ -62,28 +63,27 @@ const std::map<Client*, std::string>& CommandHandler::handleCommand(IRCMessage& 
     broadCastRawMsg(msg);
   std::cout << command << std::endl;
   return msg.getResponses();
-}  
+}
 
 void CommandHandler::Pass(const IRCMessage& msg) {
   Client* from = msg.getFrom();
   if (from->getPassword() == "")
     msg.getFrom()->setPassword(msg.getParam(0));
-}  
+}
 
 void CommandHandler::Nick(const IRCMessage& msg) {
   // TODO: Valid nick (dup)
   Client* from = msg.getFrom();
-  if (from->getNickName() == "")
-    from->setNickName(msg.getParam(0));
-}  
+  from->setNickName(msg.getParam(0));
+}
 
 void CommandHandler::User(const IRCMessage& msg) {
   Client *from = msg.getFrom();
   // <hostname> <servername>　を無視
   // TODO: Valid入れる？
-  from->setNickName(msg.getParam(0)); // 
+  from->setNickName(msg.getParam(0)); //
   from->setRealName(msg.getParam(4));
-}  
+}
 
 void CommandHandler::Join(const IRCMessage& msg) {
   Client* client = msg.getFrom();

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -1,13 +1,15 @@
 #include "CommandHandler.hpp"
 
-#include "IRCLogger.hpp"
-
 // Orthodox Cannonical Form
-CommandHandler::CommandHandler(IRCServer* server) : server_(server) {}
+CommandHandler::CommandHandler(IRCServer* server)
+  : server_(server) {
+}
 
 CommandHandler::~CommandHandler() {}
 
-CommandHandler::CommandHandler(const CommandHandler& other) { *this = other; }
+CommandHandler::CommandHandler(const CommandHandler& other) {
+  *this = other;
+}
 
 CommandHandler& CommandHandler::operator=(const CommandHandler& other) {
   if (this == &other) {
@@ -15,14 +17,103 @@ CommandHandler& CommandHandler::operator=(const CommandHandler& other) {
   }
   server_ = other.server_;
   return *this;
-}
+}  
 
 // Member functions
-const std::map<Client*, std::string>& CommandHandler::broadCastRawMsg(
-    IRCMessage& msg) {
+const std::map<Client*, std::string>& CommandHandler::handleCommand(IRCMessage& msg) {
+  IRCParser::parseRaw(msg);
+  DEBUG_MSG(
+    "CommandHandler::handleCommand from: "
+    << msg.getFrom()->getFd() << std::endl
+    << "----------------------" << std::endl
+    << msg.getRaw() << std::endl
+    << "prefix: " << msg.getPrefix() << std::endl
+    << "command: " << msg.getCommand() << std::endl
+    << "param[0]: " << msg.getParam(0) << std::endl
+    << "param[1]: " << msg.getParam(1) << std::endl
+    << "----------------------"
+  );
+
+  // コマンドごとに処理を分岐
+  std::string command = msg.getCommand();
+  DEBUG_MSG("Command: " << command);
+  if (command == "NICK")
+    Nick(msg);
+  else if (command == "USER")
+    User(msg);
+  // else if (command == "JOIN")
+  //   Join(msg);
+  // else if (command == "PRIVMSG")  
+  //   Privmsg(msg);
+  // else if (command == "PART")
+  //   Part(msg);
+  // else if (command == "QUIT")  
+  //   Quit(msg);
+  else if (command == "PING")
+    Ping(msg);
+
+  // TODO: add commands
+  /*
+    KICK, INVITE, TOPIC, MODE
+  */
+
+  // 受信したデータを他のクライアントにそのまま送信
+  else
+    broadCastRawMsg(msg);
+  std::cout << command << std::endl;
+  return msg.getResponses();
+}  
+
+void CommandHandler::Pass(const IRCMessage& msg) {
+  Client* from = msg.getFrom();
+  if (from->getPassword() == "")
+    msg.getFrom()->setPassword(msg.getParam(0));
+}  
+
+void CommandHandler::Nick(const IRCMessage& msg) {
+  // TODO: Valid nick (dup)
+  Client* from = msg.getFrom();
+  if (from->getNickName() == "")
+    from->setNickName(msg.getParam(0));
+}  
+
+void CommandHandler::User(const IRCMessage& msg) {
+  Client *from = msg.getFrom();
+  // <hostname> <servername>　を無視
+  // TODO: Valid入れる？
+  from->setNickName(msg.getParam(0)); // 
+  from->setRealName(msg.getParam(4));
+}  
+
+void CommandHandler::Join(const IRCMessage& msg) {
+  Client* client = msg.getFrom();
+  std::string channelName = msg.getParam(0);
+  if (server_->ifChannleExists(channelName) == false)
+    server_->addChannel(channelName, client);
+  else
+    server_->getChannel(channelName)->addMember(client);
+}
+
+// void CommandHandler::Privmsg(const IRCMessage& msg) {
+//   // TODO: 追って追記
+// }
+
+// void CommandHandler::Part(const IRCMessage& msg) {
+//   // TODO: 追って追記
+// }
+
+// void CommandHandler::Quit(const IRCMessage& msg) {
+//   // TODO: 追って追記
+// }
+
+void CommandHandler::Ping(IRCMessage& msg) {
+  msg.addResponse(msg.getFrom(), "PONG" + msg.getParam(0) + "\r\n");
+}
+
+const std::map<Client*, std::string>& CommandHandler::broadCastRawMsg(IRCMessage& msg) {
   for (std::map<int, Client*>::const_iterator it =
-           server_->getClients().begin();
-       it != server_->getClients().end(); ++it) {
+    server_->getClients().begin();
+    it != server_->getClients().end(); ++it) {
     if (msg.isFromMe(it->second)) {
       // 自分自身はスキップ
       continue;
@@ -32,41 +123,4 @@ const std::map<Client*, std::string>& CommandHandler::broadCastRawMsg(
     }
   }
   return msg.getResponses();
-}
-
-const std::map<Client*, std::string>& CommandHandler::handleNick(
-    IRCMessage& msg) {
-  // TODO NICKコマンドの処理をちゃんと書く
-  msg.getFrom()->setNickName("nick1");
-  return msg.getResponses();
-}
-
-const std::map<Client*, std::string>& CommandHandler::handlePing(
-    IRCMessage& msg) {
-  // TODO PINGコマンドの処理をちゃんと書く
-  msg.addResponse(msg.getFrom(), "PONG\r\n");
-  return msg.getResponses();
-}
-
-const std::map<Client*, std::string>& CommandHandler::handleCommand(
-    IRCMessage& msg) {
-  IRCParser::parseRaw(msg);
-  DEBUG_MSG("CommandHandler::handleCommand from: "
-            << msg.getFrom()->getFd() << std::endl
-            << "----------------------" << std::endl
-            << msg.getRaw() << std::endl
-            << "prefix: " << msg.getPrefix() << std::endl
-            << "command: " << msg.getCommand() << std::endl
-            << "param[0]: " << msg.getParam(0) << std::endl
-            << "param[1]: " << msg.getParam(1) << std::endl
-            << "----------------------");
-
-  // TODO コマンドを解析して処理を分岐
-  if (msg.getRaw().compare(0, 4, "NICK") == 0) {
-    return handleNick(msg);
-  } else if (msg.getRaw().compare(0, 4, "PING") == 0) {
-    return handlePing(msg);
-  }
-  // 受信したデータを他のクライアントにそのまま送信
-  return broadCastRawMsg(msg);
 }

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -97,9 +97,7 @@ bool IRCServer::addChannel(const std::string& name, Client* client) {
 }
 
 bool IRCServer::ifChannleExists(const std::string& name) const {
-  if (channels_.find(name) != channels_.end())
-    return true;
-  return false;
+  return (channels_.find(name) != channels_.end());
 }
 
 // bool IRCServer::removeClient(Client* client) {
@@ -111,15 +109,15 @@ bool IRCServer::ifChannleExists(const std::string& name) const {
 //   return false;
 // }
 
-bool IRCServer::removeChannel(const std::string& name) {
-  std::map<std::string, Channel*>::iterator it = channels_.find(name);
-  if (it != channels_.end()) {
-    delete it->second;
-    channels_.erase(it);
-    return true;
-  }
-  return false;
-}
+// bool IRCServer::removeChannel(const std::string& name) {
+//   std::map<std::string, Channel*>::iterator it = channels_.find(name);
+//   if (it != channels_.end()) {
+//     delete it->second;
+//     channels_.erase(it);
+//     return true;
+//   }
+//   return false;
+// }
 
 void IRCServer::startListen() {
   struct addrinfo hints, *res, *ai;

--- a/test/unit/src/CommandHandler/handleNick.cpp
+++ b/test/unit/src/CommandHandler/handleNick.cpp
@@ -26,27 +26,26 @@ TEST(CommandHandlerTE, handleNick1) {
   EXPECT_EQ(server.getClients().at(10)->getNickName(), expected);
 }
 
-// TODO まだニックネームがnick1の時しか実装していないので、エラーになる
-// TEST(CommandHandlerTE, handleNick2) {
-//   IRCServer server("6677", "pass123");
+TEST(CommandHandlerTE, handleNick2) {
+  IRCServer server("6677", "pass123");
 
-//   std::map<int, Client*> clients;
-//   clients[10] = new Client(10);
-//   clients[11] = new Client(11);
-//   clients[12] = new Client(12);
-//   server.addClient(clients[10]);
-//   server.addClient(clients[11]);
-//   server.addClient(clients[12]);
+  std::map<int, Client*> clients;
+  clients[10] = new Client(10);
+  clients[11] = new Client(11);
+  clients[12] = new Client(12);
+  server.addClient(clients[10]);
+  server.addClient(clients[11]);
+  server.addClient(clients[12]);
 
-//   std::string msgStr = "NICK nick2";
-//   std::string expected = "nick2";
-//   IRCMessage msg(clients[10], msgStr);
+  std::string msgStr = "NICK nick2";
+  std::string expected = "nick2";
+  IRCMessage msg(clients[10], msgStr);
 
-//   CommandHandler commandHandler(&server);
-//   commandHandler.handleNick(msg);
+  CommandHandler commandHandler(&server);
+  commandHandler.handleCommand(msg);
 
-//   const std::map<Client*, std::string> res = msg.getResponses();
+  const std::map<Client*, std::string> res = msg.getResponses();
 
-//   EXPECT_EQ(res.size(), 0);
-//   EXPECT_EQ(server.getClients().at(10)->getNickName(), expected);
-// }
+  EXPECT_EQ(res.size(), 0);
+  EXPECT_EQ(server.getClients().at(10)->getNickName(), expected);
+}

--- a/test/unit/src/CommandHandler/handleNick.cpp
+++ b/test/unit/src/CommandHandler/handleNick.cpp
@@ -19,7 +19,8 @@ TEST(CommandHandlerTE, handleNick1) {
   IRCMessage msg(clients[10], msgStr);
 
   CommandHandler commandHandler(&server);
-  const std::map<Client*, std::string> res = commandHandler.handleNick(msg);
+  commandHandler.handleCommand(msg);
+  const std::map<Client*, std::string> res = msg.getResponses();
 
   EXPECT_EQ(res.size(), 0);
   EXPECT_EQ(server.getClients().at(10)->getNickName(), expected);


### PR DESCRIPTION
## Channelクラスを追加
一旦モックのChannelクラスを作成しました
→`Channel.cpp`を参照

## `CommandHandler`の修正
### COMMAND系の修正
- いくつかのCOMMAND (NICK, USER)を一旦動くようにしました
レスポンス含めると肥大化しそうなので、追ってどこかでクラスにした方が良さそう
- `CommandHandler` 内でパース`IRCParser::parseRaw(msg);`するように変更
- 対応する単体テスト`handleNick`をアップデート
モックだった`handleNick`できちんとテストするようにしました

### e2eテスト用にPINGを修正
`> make e2e_test`
> ...
     Full diff:
    - (b'PONG\r\n')
    + b'PONG'
    ...

PONGのレスポンスで落ちているようだったので、
下記`CommandHandler::Ping`に`\r\n`を追加しました。
```C++
void CommandHandler::Ping(IRCMessage& msg) {
  msg.addResponse(msg.getFrom(), "PONG" + msg.getParam(0) + "\r\n");
}
```

## その他
その他、いくつかのフォーマット修正をしました