### PR TITLE
エラーメッセージをノンブロッキングに対応しました

### DIFF
--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -29,7 +29,7 @@ class Client {
   Client(const Client& other);
   Client& operator=(const Client& other);
 
-  public:
+ public:
   static const int kMaxSendingMsgSize = 512 * 100;  // 送信バッファサイズ
 
   // Constructor & Destructor
@@ -58,7 +58,6 @@ class Client {
   const std::string& getSendingMsg();
   size_t consumeSendingMsg(size_t size);
   void pushSendingMsg(const std::string& msg);
-  void sendMessage(const std::string& msg);
   // void setUserInfo(const std::string& user, const std::string& real);
   // bool isRegistered() const;
   // void joinChannel(Channel* channel);

--- a/include/IRCLogger.hpp
+++ b/include/IRCLogger.hpp
@@ -8,13 +8,22 @@
 #ifdef DEBUG
 #define DEBUG_MSG(msg)                                         \
   do {                                                         \
-    IRCLogger::getInstance() << "DEBUG: " << msg << std::endl; \
+    IRCLogger::getInstance()                                   \
+        << "\033[30mDEBUG: " << msg << "\033[0m" << std::endl; \
   } while (0)
 #else
-#define DEBUG_MSG(msg) \
-  do {                 \
-  } while (0)
+#define DEBUG_MSG(msg)
 #endif
+
+#define ERROR_MSG(msg)                                                        \
+  do {                                                                        \
+    IRCLogger::getInstance() << "\033[31mERROR\033[0m: " << msg << std::endl; \
+  } while (0)
+
+#define INFO_MSG(msg)                                                        \
+  do {                                                                       \
+    IRCLogger::getInstance() << "\033[36mINFO\033[0m: " << msg << std::endl; \
+  } while (0)
 
 class IRCLogger {
  public:

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <sys/socket.h>
 #include <unistd.h>
+
 #include <iostream>
 
 #include "IRCLogger.hpp"
@@ -81,12 +82,4 @@ void Client::pushSendingMsg(const std::string& msg) {
 
 void Client::pushReceivingMsg(const std::string& msg) {
   receiving_msg_ += msg;
-}  
-
-void Client::sendMessage(const std::string& msg) {
-  if (send(socket_.getFd(), msg.c_str(), msg.size(), 0) == -1) {
-    std::cerr << "send failed. fd: " << socket_.getFd()
-              << ", nick: " << nickName_ << std::endl;
-    throw std::runtime_error("send failed");
-  }
 }

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -1,9 +1,7 @@
 #include "CommandHandler.hpp"
 
 // Orthodox Cannonical Form
-CommandHandler::CommandHandler(IRCServer* server)
-  : server_(server) {
-}
+CommandHandler::CommandHandler(IRCServer* server) : server_(server) {}
 
 CommandHandler::~CommandHandler() {}
 
@@ -20,19 +18,18 @@ CommandHandler& CommandHandler::operator=(const CommandHandler& other) {
 }
 
 // Member functions
-const std::map<Client*, std::string>& CommandHandler::handleCommand(IRCMessage& msg) {
+const std::map<Client*, std::string>& CommandHandler::handleCommand(
+    IRCMessage& msg) {
   IRCParser::parseRaw(msg);
-  DEBUG_MSG(
-    "CommandHandler::handleCommand from: "
-    << msg.getFrom()->getFd() << std::endl
-    << "----------------------" << std::endl
-    << msg.getRaw() << std::endl
-    << "prefix: " << msg.getPrefix() << std::endl
-    << "command: " << msg.getCommand() << std::endl
-    << "param[0]: " << msg.getParam(0) << std::endl
-    << "param[1]: " << msg.getParam(1) << std::endl
-    << "----------------------"
-  );
+  DEBUG_MSG("CommandHandler::handleCommand from: "
+            << msg.getFrom()->getFd() << std::endl
+            << "----------------------" << std::endl
+            << msg.getRaw() << std::endl
+            << "prefix: " << msg.getPrefix() << std::endl
+            << "command: " << msg.getCommand() << std::endl
+            << "param[0]: " << msg.getParam(0) << std::endl
+            << "param[1]: " << msg.getParam(1) << std::endl
+            << "----------------------");
 
   // コマンドごとに処理を分岐
   // TODO: switch文など、もっと簡単に書けそう
@@ -61,14 +58,13 @@ const std::map<Client*, std::string>& CommandHandler::handleCommand(IRCMessage& 
   // 受信したデータを他のクライアントにそのまま送信
   else
     broadCastRawMsg(msg);
-  std::cout << command << std::endl;
+  DEBUG_MSG(command);
   return msg.getResponses();
 }
 
 void CommandHandler::Pass(const IRCMessage& msg) {
   Client* from = msg.getFrom();
-  if (from->getPassword() == "")
-    msg.getFrom()->setPassword(msg.getParam(0));
+  if (from->getPassword() == "") msg.getFrom()->setPassword(msg.getParam(0));
 }
 
 void CommandHandler::Nick(const IRCMessage& msg) {
@@ -78,10 +74,10 @@ void CommandHandler::Nick(const IRCMessage& msg) {
 }
 
 void CommandHandler::User(const IRCMessage& msg) {
-  Client *from = msg.getFrom();
+  Client* from = msg.getFrom();
   // <hostname> <servername>　を無視
   // TODO: Valid入れる？
-  from->setNickName(msg.getParam(0)); //
+  from->setNickName(msg.getParam(0));  //
   from->setRealName(msg.getParam(4));
 }
 
@@ -110,10 +106,11 @@ void CommandHandler::Ping(IRCMessage& msg) {
   msg.addResponse(msg.getFrom(), "PONG" + msg.getParam(0) + "\r\n");
 }
 
-const std::map<Client*, std::string>& CommandHandler::broadCastRawMsg(IRCMessage& msg) {
+const std::map<Client*, std::string>& CommandHandler::broadCastRawMsg(
+    IRCMessage& msg) {
   for (std::map<int, Client*>::const_iterator it =
-    server_->getClients().begin();
-    it != server_->getClients().end(); ++it) {
+           server_->getClients().begin();
+       it != server_->getClients().end(); ++it) {
     if (msg.isFromMe(it->second)) {
       // 自分自身はスキップ
       continue;

--- a/src/IOWrapper.cpp
+++ b/src/IOWrapper.cpp
@@ -14,14 +14,14 @@
 IOWrapper::IOWrapper() {
   epfd_ = epoll_create1(EPOLL_CLOEXEC);
   if (epfd_ == -1) {
-    std::cerr << "epoll_create failed\n";
+    ERROR_MSG("epoll_create failed");
     std::exit(EXIT_FAILURE);
   }
 }
 
 IOWrapper::~IOWrapper() {
   if (close(epfd_) == -1) {
-    std::cerr << "close failed" << std::endl;
+    ERROR_MSG("close epfd failed.");
     std::exit(EXIT_FAILURE);
   }
 }
@@ -32,7 +32,7 @@ bool IOWrapper::add_monitoring(int fd, uint32_t events) {
   ev.events = events;
   ev.data.fd = fd;
   if (epoll_ctl(epfd_, EPOLL_CTL_ADD, fd, &ev) == -1) {
-    std::cerr << "epoll_ctl failed" << std::endl;
+    ERROR_MSG("epoll_ctl add failed. fd: " << fd);
     return false;
   }
 #endif
@@ -45,7 +45,7 @@ bool IOWrapper::modify_monitoring(int fd, uint32_t events) {
   ev.events = events;
   ev.data.fd = fd;
   if (epoll_ctl(epfd_, EPOLL_CTL_MOD, fd, &ev) == -1) {
-    std::cerr << "epoll_ctl failed" << std::endl;
+    ERROR_MSG("epoll_ctl modify failed. fd: " << fd);
     return false;
   }
 #endif
@@ -55,7 +55,7 @@ bool IOWrapper::modify_monitoring(int fd, uint32_t events) {
 bool IOWrapper::remove_monitoring(int fd) {
 #ifndef UNIT_TEST
   if (epoll_ctl(epfd_, EPOLL_CTL_DEL, fd, NULL) == -1) {
-    std::cerr << "epoll_ctl failed" << std::endl;
+    ERROR_MSG("epoll_ctl remove failed. fd: " << fd);
     return false;
   }
 #endif
@@ -69,8 +69,8 @@ int IOWrapper::wait_monitoring(epoll_event* events) {
 bool IOWrapper::sendMessage(Client* client, const std::string& msg) {
   client->pushSendingMsg(msg);
   if (client->getSendingMsg().size() > Client::kMaxSendingMsgSize) {
-    std::cerr << "Sending message size exceeds limit: "
-              << client->getSendingMsg().size() << std::endl;
+    ERROR_MSG("Sending message size exceeds limit: "
+              << client->getSendingMsg().size());
     return false;
   }
   return sendMessage(client);
@@ -97,7 +97,7 @@ bool IOWrapper::sendMessage(Client* client) {
         pending_write_fds_.insert(client->getFd());
         return true;
       } else {
-        std::cerr << "send failed. fd: " << client->getFd() << std::endl;
+        ERROR_MSG("send failed. fd: " << client->getFd());
         return false;
       }
     }
@@ -131,7 +131,7 @@ bool IOWrapper::writeLog() {
         pending_write_fds_.insert(log_fd);
         return true;
       } else {
-        std::cerr << "write failed" << std::endl;
+        ERROR_MSG("write failed");
         return false;
       }
     }

--- a/src/IRCLogger.cpp
+++ b/src/IRCLogger.cpp
@@ -1,8 +1,11 @@
 
 
 #include "IRCLogger.hpp"
+
 #include <unistd.h>
+
 #include <iostream>
+
 #include "IOWrapper.hpp"
 
 IRCLogger& IRCLogger::getInstance() {
@@ -18,7 +21,10 @@ IRCLogger::IRCLogger() {
   }
 }
 
-IRCLogger::~IRCLogger() {}
+IRCLogger::~IRCLogger() {
+  std::cerr << log_;
+  std::cerr.flush();
+}
 
 const std::string& IRCLogger::getLog() const {
   return log_;

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -1,18 +1,17 @@
 #include "Socket.hpp"
+
 #include <unistd.h>
+
 #include <iostream>
+
 #include "IOWrapper.hpp"
 #include "IRCLogger.hpp"
 
 Socket::Socket(int fd) : fd_(fd) {
-  if (fd_ < 0) {
-    throw std::runtime_error("socket(2) failed");
-  }
   // ソケットをノンブロッキングに設定
   if (!IOWrapper::setNonBlockingFlag(fd_)) {
-    std::cerr << "fcntl: set non-blocking flag failed: fd" << fd_ << std::endl;
+    ERROR_MSG("fcntl: set non-blocking flag failed: fd" << fd_);
     close(fd_);
-    throw std::runtime_error("fcntl: set non-blocking flag failed");
   }
   DEBUG_MSG("Socket created fd: " << fd_);
 }
@@ -20,7 +19,7 @@ Socket::Socket(int fd) : fd_(fd) {
 Socket::~Socket() {
   if (fd_ != -1) {
     if (close(fd_) == -1) {
-      std::cerr << "close failed" << std::endl;
+      ERROR_MSG("close failed");
     }
     DEBUG_MSG("Socket closed fd: " << fd_);
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,20 @@
 #include <iostream>
+
+#include "IRCLogger.hpp"
 #include "IRCServer.hpp"
 
 int main(int argc, char* argv[]) {
-  if (argc != 3) {
-    std::cerr << "Usage: " << argv[0] << " <port> <password>" << std::endl;
+  try {
+    if (argc != 3) {
+      INFO_MSG("Usage: ircserv <port> <password>");
+      return 1;
+    }
+    IRCServer server(argv[1], argv[2]);
+    server.startListen();
+    server.run();
+  } catch (const std::exception& e) {
+    std::cerr << "Exception: " << e.what() << std::endl;
     return 1;
   }
-  IRCServer server(argv[1], argv[2]);
-  server.startListen();
-  server.run();
   return 0;
 }


### PR DESCRIPTION
何度もすみません。
影響するファイル数が多くてコンフリクトが起きそうなので・・・

エラーメッセージをノンブロッキングに対応しました。

### 使用方法
DEBUG_MSGと同じです。
```
ERROR_MSG("abc" << i << "xyz")
```

C++でプリプロセッサ（define）はあまり使用しない方がいいみたいなのですが、
inlineはヘッダに実装を書くことになり、42の規約的に問題がありそうなので、
他に良い実装方法が思い付きませんでした。

