### PR TITLE
ポート番号、パスワードのバリデーション追加

### DIFF
--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -20,7 +20,8 @@ class IRCServer {
   std::string password_;
   std::map<int, Socket*> listenSockets_;  // ソケットFD→listeningソケット
   std::map<int, Client*> clients_;        // ソケットFD→クライアント
-  std::map<std::string, Channel*> channels_;  // チャンネル名→チャンネルオブジェクト
+  std::map<std::string, Channel*>
+      channels_;  // チャンネル名→チャンネルオブジェクト
   // UserManager userManager_;
   // ChannelManager channelManager_;
   // Logger logger_;
@@ -46,6 +47,8 @@ class IRCServer {
   const std::map<int, Client*>& getClients() const;
   const std::map<std::string, Channel*>& getChannels() const;
   Channel* getChannel(const std::string& name) const;
+  const std::string& getPort() const;
+  const std::string& getPassword() const;
 
   // Setters
   bool addClient(Client* client);

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -18,14 +18,53 @@
 #include "IRCMessage.hpp"
 #include "Utils.hpp"
 
+static bool isValidPort(const char* port_str) {
+  if (port_str == NULL) {
+    return false;
+  }
+  int i = 0;
+  while (port_str[i] != '\0') {
+    if (!std::isdigit(port_str[i])) {
+      return false;
+    }
+    i++;
+  }
+  if (i > 6) {
+    return false;
+  }
+  int port_num = std::atoi(port_str);
+  if (port_num < 1 || 65535 < port_num) {
+    return false;
+  }
+  return true;
+}
+
+static bool isValidPassword(const char* password_str) {
+  if (password_str == NULL) {
+    return false;
+  }
+  int i = 0;
+  while (password_str[i] != '\0') {
+    i++;
+  }
+  if (i < 1 || 100 < i) {
+    return false;
+  }
+  return true;
+}
+
 // Constructor & Destructor
 IRCServer::IRCServer(const char* port, const char* password) {
   IOWrapper io_;
 
-  // TODO: ポート番号のバリデーション
-  std::istringstream ss(port);
-  ss >> port_;
+  if (!isValidPort(port)) {
+    throw std::invalid_argument("invalid port number");
+  }
+  port_ = std::string(port);
 
+  if (!isValidPassword(password)) {
+    throw std::invalid_argument("invalid password");
+  }
   password_ = std::string(password);
 
   // ログ出力をノンブロッキングに設定
@@ -78,6 +117,14 @@ Channel* IRCServer::getChannel(const std::string& name) const {
     return it->second;
   }
   return NULL;
+}
+
+const std::string& IRCServer::getPort() const {
+  return port_;
+}
+
+const std::string& IRCServer::getPassword() const {
+  return password_;
 }
 
 // Setters

--- a/test/unit/src/IRCServer.cpp
+++ b/test/unit/src/IRCServer.cpp
@@ -1,0 +1,89 @@
+#include "IRCServer.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(IRCServerTest, valid_construnctor) {
+  {
+    const char* port = "6667";
+    const char* password = "password";
+    IRCServer server(port, password);
+    EXPECT_EQ(server.getPort(), std::string(port));
+    EXPECT_EQ(server.getPassword(), std::string(password));
+  }
+  {
+    const char* port = "1";
+    const char* password = "p";
+    IRCServer server(port, password);
+    EXPECT_EQ(server.getPort(), std::string(port));
+    EXPECT_EQ(server.getPassword(), std::string(password));
+  }
+  {
+    const char* port = "65535";
+    const char* password =
+        "1234567890123456789012345678901234567890123456789012345678901234567890"
+        "123456789012345678901234567890";
+    IRCServer server(port, password);
+    EXPECT_EQ(server.getPort(), std::string(port));
+    EXPECT_EQ(server.getPassword(), std::string(password));
+  }
+}
+TEST(IRCServerTest, invalid_port) {
+  {
+    const char* port = "0";
+    const char* password = "password";
+    try {
+      IRCServer server(port, password);
+    } catch (const std::invalid_argument& e) {
+      EXPECT_STREQ(e.what(), "invalid port number");
+    }
+  }
+  {
+    const char* port = "65536";  // 65535より大きい
+    const char* password = "password";
+    try {
+      IRCServer server(port, password);
+    } catch (const std::invalid_argument& e) {
+      EXPECT_STREQ(e.what(), "invalid port number");
+    }
+  }
+  {
+    const char* port = "6667a";
+    const char* password = "password";
+    try {
+      IRCServer server(port, password);
+    } catch (const std::invalid_argument& e) {
+      EXPECT_STREQ(e.what(), "invalid port number");
+    }
+  }
+  {
+    const char* port = "";
+    const char* password = "password";
+    try {
+      IRCServer server(port, password);
+    } catch (const std::invalid_argument& e) {
+      EXPECT_STREQ(e.what(), "invalid port number");
+    }
+  }
+}
+TEST(IRCServerTest, invalid_password) {
+  {
+    const char* port = "6667";
+    const char* password = "";
+    try {
+      IRCServer server(port, password);
+    } catch (const std::invalid_argument& e) {
+      EXPECT_STREQ(e.what(), "invalid password");
+    }
+  }
+  {
+    const char* port = "6667";
+    const char* password =
+        "1234567890123456789012345678901234567890123456789012345678901234567890"
+        "1234567890123456789012345678901";
+    try {
+      IRCServer server(port, password);
+    } catch (const std::invalid_argument& e) {
+      EXPECT_STREQ(e.what(), "invalid password");
+    }
+  }
+}


### PR DESCRIPTION
ポート番号
- 1以上、65535以下かチェック（上限値はシステム上の制約）
- その他数値以外の文字が含まれていないかチェック

パスワード
- 1文字以上、100文字以下（上限値に特に理由はありません。適当に決めました）
