### PR TITLE
fcntl()とwrite()を使用しないように変更

### DIFF
--- a/include/IOWrapper.hpp
+++ b/include/IOWrapper.hpp
@@ -13,6 +13,7 @@ typedef struct epoll_event io_event;
 class IOWrapper {
  public:
   static const int kEpollMaxEvents = 10000;
+  static const int kRecvBufferSize = 1024;
 
   IOWrapper();
   ~IOWrapper();
@@ -24,6 +25,8 @@ class IOWrapper {
 
   bool sendMessage(Client* client, const std::string& msg);
   bool sendMessage(Client* client);
+
+  bool receiveMessage(Client* client, std::string& msg);
 
   bool writeLog(int fd);
 

--- a/include/IOWrapper.hpp
+++ b/include/IOWrapper.hpp
@@ -25,9 +25,7 @@ class IOWrapper {
   bool sendMessage(Client* client, const std::string& msg);
   bool sendMessage(Client* client);
 
-  bool writeLog();
-
-  static bool setNonBlockingFlag(int fd);
+  bool writeLog(int fd);
 
  private:
   int epfd_;                         // epollのファイルディスクリプタ

--- a/include/IRCLogger.hpp
+++ b/include/IRCLogger.hpp
@@ -11,20 +11,22 @@
     IRCLogger::getInstance()                                   \
         << "\033[30mDEBUG: " << msg << "\033[0m" << std::endl; \
   } while (0)
-#else
-#define DEBUG_MSG(msg)
-#endif
-
 #define ERROR_MSG(msg)                                                        \
   do {                                                                        \
     IRCLogger::getInstance() << "\033[31mERROR\033[0m: " << msg << std::endl; \
   } while (0)
-
 #define INFO_MSG(msg)                                                        \
   do {                                                                       \
     IRCLogger::getInstance() << "\033[36mINFO\033[0m: " << msg << std::endl; \
   } while (0)
 
+#else
+#define DEBUG_MSG(msg)
+#define ERROR_MSG(msg)
+#define INFO_MSG(msg)
+#endif
+
+#ifdef DEBUG
 class IRCLogger {
  public:
   // シングルトン
@@ -59,5 +61,6 @@ class IRCLogger {
   IRCLogger(const IRCLogger& other);
   IRCLogger& operator=(const IRCLogger& other);
 };
+#endif  // DEBUG
 
 #endif  // __IRC_LOGGER_HPP__

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -31,9 +31,8 @@ class IRCServer {
   void resendClientMessage(int clientFd);
   void disconnectClient(Client* client);
 
-  static const int BUFFER_SIZE = 1024;
-  static const int MAX_MSG_SIZE = 510;  // IRCの仕様
-  static const int MAX_BACKLOG = 100;
+  static const int kMaxMsgSize = 510;  // IRCの仕様
+  static const int kMaxBacklog = 100;
 
  public:
   // Orthodox Canonical Form

--- a/src/IOWrapper.cpp
+++ b/src/IOWrapper.cpp
@@ -84,7 +84,7 @@ bool IOWrapper::sendMessage(Client* client) {
   }
   while (msg_size > 0) {
     ssize_t bytes_sent = send(client->getFd(), client->getSendingMsg().c_str(),
-                              client->getSendingMsg().size(), 0);
+                              client->getSendingMsg().size(), MSG_DONTWAIT);
     if (bytes_sent >= 0) {
       // 送信したバイト数を送信待ちメッセージから削除
       msg_size = client->consumeSendingMsg(bytes_sent);
@@ -110,16 +110,20 @@ bool IOWrapper::sendMessage(Client* client) {
   return true;
 }
 
-bool IOWrapper::writeLog() {
+bool IOWrapper::writeLog(int fd) {
+#ifdef DEBUG
+  if (fd != IRCLogger::getInstance().getFd() && fd != -1) {
+    return true;
+  }
   int log_fd = IRCLogger::getInstance().getFd();
   size_t log_size = IRCLogger::getInstance().getLog().size();
   if (log_size == 0) {
     return true;
   }
   while (log_size > 0) {
-    ssize_t bytes_written =
-        write(STDERR_FILENO, IRCLogger::getInstance().getLog().c_str(),
-              IRCLogger::getInstance().getLog().size());
+    ssize_t bytes_written = write(IRCLogger::getInstance().getFd(),
+                                  IRCLogger::getInstance().getLog().c_str(),
+                                  IRCLogger::getInstance().getLog().size());
     if (bytes_written >= 0) {
       log_size = IRCLogger::getInstance().consumeLog(bytes_written);
       continue;
@@ -141,18 +145,8 @@ bool IOWrapper::writeLog() {
     modify_monitoring(log_fd, EPOLLIN | EPOLLET);
     pending_write_fds_.erase(log_fd);
   }
-  return true;
-}
-
-bool IOWrapper::setNonBlockingFlag(int fd) {
-#ifndef UNIT_TEST
-  int flags = fcntl(fd, F_GETFL, 0);
-  if (flags == -1) {
-    return false;
-  }
-  if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
-    return false;
-  }
+#else
+  (void)fd;
 #endif
   return true;
 }

--- a/src/IRCLogger.cpp
+++ b/src/IRCLogger.cpp
@@ -2,12 +2,14 @@
 
 #include "IRCLogger.hpp"
 
+#include <fcntl.h>
 #include <unistd.h>
 
 #include <iostream>
 
 #include "IOWrapper.hpp"
 
+#ifdef DEBUG
 IRCLogger& IRCLogger::getInstance() {
   static IRCLogger instance;
   return instance;
@@ -15,9 +17,9 @@ IRCLogger& IRCLogger::getInstance() {
 
 IRCLogger::IRCLogger() {
   log_ = "";
-  fd_ = STDERR_FILENO;
-  if (!IOWrapper::setNonBlockingFlag(fd_)) {
-    throw std::runtime_error("fcntl: set non-blocking flag failed");
+  fd_ = open("/dev/stderr", O_WRONLY | O_NONBLOCK);
+  if (fd_ < 0) {
+    throw std::runtime_error("cannot open log file");
   }
 }
 
@@ -42,3 +44,4 @@ size_t IRCLogger::consumeLog(size_t size) {
   log_.erase(0, size);
   return log_.size();
 }
+#endif  // DEBUG

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -210,7 +210,7 @@ void IRCServer::startListen() {
       close(sockfd);
       continue;
     }
-    if (listen(sockfd, MAX_BACKLOG) < 0) {
+    if (listen(sockfd, kMaxBacklog) < 0) {
       close(sockfd);
       continue;
     }
@@ -277,28 +277,16 @@ void IRCServer::handleClientMessage(int clientFd) {
     return;
   }
   // クライアントからのデータを受信した場合
-  char buffer[BUFFER_SIZE];
-  ssize_t bytesRead =
-      recv(it_from->first, buffer, sizeof(buffer), MSG_DONTWAIT);
-  if (bytesRead == 0) {
-    // クライアントが切断された場合
+  std::string msg = "";
+  if (!io_.receiveMessage(it_from->second, msg)) {
     disconnectClient(it_from->second);
     return;
   }
-  if (bytesRead < 0) {
-    // ノンブロッキングの場合
-    if (errno == EAGAIN || errno == EWOULDBLOCK) {
-      // 受信待ち
-      return;
-    }
-    // recv失敗
-    disconnectClient(it_from->second);
-    ERROR_MSG("recv failed. fd: " << it_from->first);
+  if (msg.empty()) {
+    // 受信したメッセージが空、またはブロックされた場合は何もしない
     return;
   }
-  // bytesRead > 0
-  std::string msg =
-      it_from->second->popReceivingMsg() + std::string(buffer, bytesRead);
+
   // CRLFで分割して処理
   std::vector<std::string> split_msgs = Utils::split(msg, "\r\n");
 
@@ -308,22 +296,22 @@ void IRCServer::handleClientMessage(int clientFd) {
     split_msgs.pop_back();
   }
 
-  CommandHandler commandHandler(this);
   for (std::vector<std::string>::iterator it = split_msgs.begin();
        it != split_msgs.end(); ++it) {
     // msgが510(CRLFを含めて512)を超えていたら切断
-    if (it->size() > IRCServer::MAX_MSG_SIZE) {
+    if (it->size() > IRCServer::kMaxMsgSize) {
       DEBUG_MSG("Message too long: " << it->size());
       disconnectClient(it_from->second);
       return;
     }
     IRCMessage msg(it_from->second, *it);
+    CommandHandler commandHandler(this);
     const std::map<Client*, std::string>& res =
         commandHandler.handleCommand(msg);
     sendResponses(res);
   }
   // receiving_msg_が510を超えていたら切断
-  if (it_from->second->getReceivingMsg().size() > IRCServer::MAX_MSG_SIZE) {
+  if (it_from->second->getReceivingMsg().size() > IRCServer::kMaxMsgSize) {
     DEBUG_MSG(
         "Message too long: " << it_from->second->getReceivingMsg().size());
     disconnectClient(it_from->second);

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -8,11 +8,6 @@
 #include "IRCLogger.hpp"
 
 Socket::Socket(int fd) : fd_(fd) {
-  // ソケットをノンブロッキングに設定
-  if (!IOWrapper::setNonBlockingFlag(fd_)) {
-    ERROR_MSG("fcntl: set non-blocking flag failed: fd" << fd_);
-    close(fd_);
-  }
   DEBUG_MSG("Socket created fd: " << fd_);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,14 +6,14 @@
 int main(int argc, char* argv[]) {
   try {
     if (argc != 3) {
-      INFO_MSG("Usage: ircserv <port> <password>");
+      std::cout << "Usage: ircserv <port> <password>" << std::endl;
       return 1;
     }
     IRCServer server(argv[1], argv[2]);
     server.startListen();
     server.run();
   } catch (const std::exception& e) {
-    std::cerr << "Exception: " << e.what() << std::endl;
+    std::cerr << "Error: " << e.what() << std::endl;
     return 1;
   }
   return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 int main(int argc, char* argv[]) {
   try {
     if (argc != 3) {
-      std::cout << "Usage: ircserv <port> <password>" << std::endl;
+      std::cerr << "Usage: ircserv <port> <password>" << std::endl;
       return 1;
     }
     IRCServer server(argv[1], argv[2]);


### PR DESCRIPTION
fcntl()関数はMacの場合でしか使用してはいけないようなので、（課題PDFの6ページ, III.2）
別の方法でノンブロッキングIOを実現するように変更しました。

write()関数は使用可能関数に入っていなかったため、
本番環境ではエラー含めてログ出力を一切しないように変更しました。

main関数にstd::cerrを残していますが、これはIRCサーバーが起動する前の
引数のエラーチェックの時にしか動かない想定です。
これはブロッキングIOのため、課題PDFの5ページの注意書き（下記）に違反していますが、
流石にそれも出さないのはちょっと無理がある気がするので残しました。
```
Because you have to use non-blocking file descriptors, it is possible to use read/recv or write/send functions with no poll()
(or equivalent), and your server wouldn’t be blocking. However, it would consume more system resources. Therefore, if you attempt to read/recv or write/send in any file descriptor without using poll() (or equivalent), your grade will be 0.
```

