### PR TITLE
Add command TOPIC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SRCS := src/main.cpp src/IRCServer.cpp src/Client.cpp src/Channel.cpp\
 		src/commands/CommandUser.cpp src/commands/CommandPing.cpp \
 		src/commands/CommandJoin.cpp src/commands/CommandTopic.cpp \
 		src/commands/CommandPrivMsg.cpp \
-		src/commands/CommandBroadCast.cpp
+		src/commands/CommandBroadCast.cpP
 OBJS = $(patsubst $(SRCS_ROOT_DIR)/%.cpp,$(OBJS_ROOT_DIR)/%.o,$(SRCS))
 
 #-----------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ SRCS := src/main.cpp src/IRCServer.cpp src/Client.cpp src/Channel.cpp\
 		src/commands/CommandUser.cpp src/commands/CommandPing.cpp \
 		src/commands/CommandJoin.cpp src/commands/CommandTopic.cpp \
 		src/commands/CommandPrivMsg.cpp \
-		src/commands/CommandBroadCast.cpP
+		src/commands/CommandBroadCast.cpp
 OBJS = $(patsubst $(SRCS_ROOT_DIR)/%.cpp,$(OBJS_ROOT_DIR)/%.o,$(SRCS))
 
 #-----------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ SRCS := src/main.cpp src/IRCServer.cpp src/Client.cpp src/Channel.cpp\
 		src/commands/ACommand.cpp src/commands/CommandCap.cpp \
 		src/commands/CommandNick.cpp src/commands/CommandPass.cpp \
 		src/commands/CommandUser.cpp src/commands/CommandPing.cpp \
-		src/commands/CommandJoin.cpp src/commands/CommandPrivMsg.cpp \
+		src/commands/CommandJoin.cpp src/commands/CommandTopic.cpp \
+		src/commands/CommandPrivMsg.cpp \
 		src/commands/CommandBroadCast.cpp
 OBJS = $(patsubst $(SRCS_ROOT_DIR)/%.cpp,$(OBJS_ROOT_DIR)/%.o,$(SRCS))
 

--- a/include/commands/CommandCap.hpp
+++ b/include/commands/CommandCap.hpp
@@ -4,6 +4,13 @@
 
 #include "ACommand.hpp"
 
+/**
+  @brief IRC command "CAP" handler.
+  @details This class handles the "CAP" command in IRC, which is used for
+           capability negotiation between the client and server.
+  @url https://ircv3.net/specs/core/capability-negotiation-3.1.html
+*/
+
 class CommandCap : public ACommand {
  public:
   // Orthodox Canonical Form

--- a/include/commands/CommandNick.hpp
+++ b/include/commands/CommandNick.hpp
@@ -4,6 +4,10 @@
 
 #include "ACommand.hpp"
 
+/**
+  @brief IRC command "NICK" handler.
+*/
+
 class CommandNick : public ACommand {
  public:
   // Orthodox Canonical Form

--- a/include/commands/CommandPass.hpp
+++ b/include/commands/CommandPass.hpp
@@ -4,6 +4,12 @@
 
 #include "ACommand.hpp"
 
+/**
+  @brief IRC command "PASS" handler.
+  @details This class handles the "PASS" command in IRC, which is used for
+           password authentication during the connection registration process.
+*/
+
 class CommandPass : public ACommand {
  public:
   // Orthodox Canonical Form

--- a/include/commands/CommandPing.hpp
+++ b/include/commands/CommandPing.hpp
@@ -4,6 +4,10 @@
 
 #include "ACommand.hpp"
 
+/**
+  @brief IRC command "PING" handler.
+*/
+
 class CommandPing : public ACommand {
  public:
   // Orthodox Canonical Form

--- a/include/commands/CommandPrivMsg.hpp
+++ b/include/commands/CommandPrivMsg.hpp
@@ -4,6 +4,10 @@
 
 #include "ACommand.hpp"
 
+/**
+  @brief IRC command "PRIVMSG" handler.
+*/
+
 class CommandPrivMsg : public ACommand {
  public:
   // Orthodox Canonical Form

--- a/include/commands/CommandTopic.hpp
+++ b/include/commands/CommandTopic.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#ifndef __COMMAND_TOPIC_HPP__
+#define __COMMAND_TOPIC_HPP__
+
+#include "ACommand.hpp"
+
+/**
+  @brief IRC command "TOPIC" handler.
+*/
+
+class CommandTopic : public ACommand {
+ public:
+  // Orthodox Canonical Form
+  CommandTopic(IRCServer* server);
+  ~CommandTopic();
+
+  // Member functions
+  void execute(IRCMessage& msg);
+
+ private:
+  CommandTopic();
+  CommandTopic(const CommandTopic& other);
+  CommandTopic& operator=(const CommandTopic& other);
+
+  bool validateTopic(IRCMessage& msg, IRCMessage& reply);
+};
+
+#endif  // __COMMAND_TOPIC_HPP__

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -22,7 +22,7 @@ RequestHandler::RequestHandler(IRCServer* server) : server_(server) {
   commands_["JOIN"] = new CommandJoin(server_);
   // commands_["PART"] = new CommandPart(server_, "PART");
   // commands_["PART"] = new CommandPart(server_);
-  // commands_["TOPIC"] = new CommandTopic(server_);
+  commands_["TOPIC"] = new CommandTopic(server_);
   // commands_["MODE"] = new CommandMode(server_);
   commands_["PRIVMSG"] = new CommandPrivMsg(server_);
   commands_["PING"] = new CommandPing(server_);

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -8,6 +8,7 @@
 #include "CommandPrivMsg.hpp"
 #include "CommandUser.hpp"
 #include "CommandJoin.hpp"
+#include "CommandTopic.hpp"
 #include "IRCLogger.hpp"
 #include "IRCParser.hpp"
 #include "IRCServer.hpp"
@@ -20,10 +21,11 @@ RequestHandler::RequestHandler(IRCServer* server) : server_(server) {
   commands_["USER"] = new CommandUser(server_);
   commands_["JOIN"] = new CommandJoin(server_);
   // commands_["PART"] = new CommandPart(server_, "PART");
+  // commands_["PART"] = new CommandPart(server_);
+  // commands_["TOPIC"] = new CommandTopic(server_);
+  // commands_["MODE"] = new CommandMode(server_);
   commands_["PRIVMSG"] = new CommandPrivMsg(server_);
-  // commands_["QUIT"] = new CommandQuit(server_, "QUIT");
   commands_["PING"] = new CommandPing(server_);
-  // commands_["PONG"] = new CommandPong(server_, "PONG");
   commands_["BROADCAST"] = new CommandBroadCast(server_);
 }
 

--- a/src/commands/ACommand.cpp
+++ b/src/commands/ACommand.cpp
@@ -102,9 +102,10 @@ std::string ACommand::generateResponseMsg(IRCMessage& reply_msg) {
       //   values);
 
       // Channel Operations
-      // case RPL_TOPIC:  // 332
-      //   // <channel> :<topic>
-      //   return formatResponse(responseCode, "%s :%s", values);
+      case RPL_TOPIC:  // 332
+        // <channel> :<topic>
+        oss << reply_msg.getParam(0) << " :" << reply_msg.getParam(1);
+        return oss.str();
       // case RPL_NAMREPLY:  // 353
       //   // <channel> :[[@|+]<nick> [[@|+]<nick> [...]]]
       //   return formatResponse(responseCode, "%s :%s", values);
@@ -224,11 +225,11 @@ std::string ACommand::generateResponseMsg(IRCMessage& reply_msg) {
       //   // <channel> :Cannot join channel (+k)
       //   return formatResponse(responseCode, "%s :Cannot join channel (+k)",
       //                         values);
-      // case ERR_CHANOPRIVSNEEDED:  // 482
-      //   // <channel> :You're not channel operator
-      //   return formatResponse(responseCode, "%s :You're not channel
-      //   operator",
-      //                         values);
+      case ERR_CHANOPRIVSNEEDED:  // 482
+        // <channel> :You're not channel operator
+        oss << reply_msg.getParam(0)
+            << " :You're not channel operator";
+        return oss.str();
     default:
       return "";
   }

--- a/src/commands/CommandCap.cpp
+++ b/src/commands/CommandCap.cpp
@@ -2,13 +2,6 @@
 
 #include "IRCLogger.hpp"
 
-/*
-  @brief IRC command "CAP" handler.
-  @details This class handles the "CAP" command in IRC, which is used for
-           capability negotiation between the client and server.
-  @url https://ircv3.net/specs/core/capability-negotiation-3.1.html
-*/
-
 CommandCap::CommandCap(IRCServer* server) : ACommand(server, "CAP") {}
 CommandCap::~CommandCap() {}
 

--- a/src/commands/CommandNick.cpp
+++ b/src/commands/CommandNick.cpp
@@ -1,9 +1,5 @@
 #include "CommandNick.hpp"
 
-/*
-  @brief IRC command "NICK" handler.
-*/
-
 #include "IRCParser.hpp"
 
 CommandNick::CommandNick(IRCServer* server) : ACommand(server, "NICK") {}

--- a/src/commands/CommandPass.cpp
+++ b/src/commands/CommandPass.cpp
@@ -1,11 +1,5 @@
 #include "CommandPass.hpp"
 
-/*
-  @brief IRC command "PASS" handler.
-  @details This class handles the "PASS" command in IRC, which is used for
-           password authentication during the connection registration process.
-*/
-
 CommandPass::CommandPass(IRCServer* server) : ACommand(server, "PASS") {}
 
 CommandPass::~CommandPass() {}

--- a/src/commands/CommandPing.cpp
+++ b/src/commands/CommandPing.cpp
@@ -1,9 +1,5 @@
 #include "CommandPing.hpp"
 
-/*
-  @brief IRC command "PONG" handler.
-*/
-
 CommandPing::CommandPing(IRCServer* server) : ACommand(server, "PING") {}
 
 CommandPing::~CommandPing() {}

--- a/src/commands/CommandPrivMsg.cpp
+++ b/src/commands/CommandPrivMsg.cpp
@@ -1,9 +1,5 @@
 #include "CommandPrivMsg.hpp"
 
-/*
-  @brief IRC command "NICK" handler.
-*/
-
 #include "IRCParser.hpp"
 
 CommandPrivMsg::CommandPrivMsg(IRCServer* server)

--- a/src/commands/CommandTopic.cpp
+++ b/src/commands/CommandTopic.cpp
@@ -1,0 +1,61 @@
+#include "CommandTopic.hpp"
+
+#include "IRCParser.hpp"
+
+CommandTopic::CommandTopic(IRCServer* server)
+    : ACommand(server, "TOPIC") {}
+
+CommandTopic::~CommandTopic() {}
+
+bool CommandTopic::validateTopic(IRCMessage& msg, IRCMessage& reply) {
+  // 引数なし
+  if (msg.getParam(0).empty()) {
+    reply.setResCode(ERR_NORECIPIENT);
+    pushResponse(reply);
+    return false;
+  }
+  // 引数が1つより多い
+  if (msg.getParams().size() > 2) {
+    reply.setResCode(ERR_NEEDMOREPARAMS);
+    pushResponse(reply);
+    return false;
+  }
+  return true;
+}
+
+void CommandTopic::execute(IRCMessage& msg) {
+  Client* from = msg.getFrom();
+  IRCMessage reply(from, from);
+  reply.setParams(msg.getParams());
+  std::string channel_name = msg.getParam(0);
+  std::string topic = msg.getParam(1);
+
+  if (!validateTopic(msg, reply)) {
+    return;
+  }
+  Channel* channel = server_->getChannel(channel_name);
+  if (!channel) {
+    reply.setResCode(ERR_NOSUCHCHANNEL);
+    reply.addParam(channel_name);
+    pushResponse(reply);
+    return;
+  }
+  if (topic.empty()) {
+    // トピックが空の場合、現在のトピックを取得
+    reply.setResCode(RPL_TOPIC);
+    reply.addParam(channel->getTopic());
+    pushResponse(reply);
+    return;
+  }
+  // トピックを設定
+  if (!channel->isChanop(from)) {
+    reply.setResCode(ERR_CHANOPRIVSNEEDED);
+    reply.addParam(channel_name);
+    pushResponse(reply);
+    return;
+  }
+  channel->setTopic(topic);
+  reply.setResCode(RPL_TOPIC);
+  reply.addParam(channel->getTopic());
+  pushResponse(reply);
+}

--- a/test/unit/src/Commands/TestCommandTopic.cpp
+++ b/test/unit/src/Commands/TestCommandTopic.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+
+#include "IRCServer.hpp"
+#include "RequestHandler.hpp"
+
+static void makeUserData(IRCServer &server, std::map<int, Client *> &clients) {
+  clients[10] = new Client(10);
+  clients[10]->setNickName("nick1");
+  clients[10]->setUserName("user1");
+  clients[10]->setIsRegistered(true);
+  server.addChannel("#channel1", clients[10]);  // チャンネルに参加
+  server.getChannel("#channel1")->setTopic("Initial topic");
+}
+
+// 通常
+TEST(CommandTopic, nomal1) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  makeUserData(server, clients);
+  RequestHandler requestHandler(&server);
+
+  std::string msgStr = "TOPIC #channel1";
+  std::string expected = ":irc.example.net 332 nick1 #channel1 :Initial topic";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected + "\r\n");
+}


### PR DESCRIPTION
## TOPICコマンドを追加しました。
コマンド一旦追加しました。
テストも一旦正常系のみ作成
->権限処理（MODEコマンド）によって状況変わりそうなんで、一旦軽めに作っています。

### TODO
- TOPIC変更後のチャンネルメンバーへのブロードキャスト（未実装）
`:nick2!~a@localhost TOPIC #ch01 :second topic`みたいな感じになっていそう

### 参考（ngircdでの挙動確認）
```sh
nc localhost 6667
```

[nick1]
```
JOIN #ch01
:nick1!~a@localhost JOIN :#ch01
:irc.example.net 353 nick1 = #ch01 :@nick1
:irc.example.net 366 nick1 #ch01 :End of NAMES list

:nick2!~a@localhost JOIN :#ch01

TOPIC #ch01 :first topic
:nick1!~a@localhost TOPIC #ch01 :first topic

:nick2!~a@localhost TOPIC #ch01 :second topic
```

[nick2]
```
JOIN #ch01
:nick2!~a@localhost JOIN :#ch01
:irc.example.net 353 nick2 = #ch01 :nick2 @nick1
:irc.example.net 366 nick2 #ch01 :End of NAMES list

:nick1!~a@localhost TOPIC #ch01 :first topic

JOIN #ch01

TOPIC #ch01 :second topic
:nick2!~a@localhost TOPIC #ch01 :second topic
```