### PR TITLE
ニックネームの変更を他のユーザーに通知

### DIFF
--- a/Makefile.old
+++ b/Makefile.old
@@ -1,0 +1,38 @@
+NAME := ircserv
+
+SRCS := src/main.cpp src/IRCServer.cpp src/Client.cpp src/Channel.cpp\
+		src/RequestHandler.cpp src/IRCMessage.cpp src/Socket.cpp \
+		src/IRCParser.cpp src/Utils.cpp src/IOWrapper.cpp src/IRCLogger.cpp \
+		src/IRCSignal.cpp \
+		src/commands/ACommand.cpp src/commands/CommandCap.cpp \
+		src/commands/CommandNick.cpp src/commands/CommandPass.cpp \
+		src/commands/CommandUser.cpp src/commands/CommandPing.cpp \
+		src/commands/CommandJoin.cpp src/commands/CommandTopic.cpp \
+		src/commands/CommandMode.cpp src/commands/CommandPrivMsg.cpp \
+		src/commands/CommandBroadCast.cpp
+
+OBJS := $(SRCS:.cpp=.o)
+CXXFLAGS += -I./include -I./include/commands -Wall -Wextra -Werror -O0 -g -std=c++98 -pedantic-errors -DDEBUG
+ifdef PROD_FLG
+CXXFLAGS := -I./include -I./include/commands -Wall -Wextra -Werror -O2 -std=c++98 -pedantic-errors
+endif
+CXX := c++
+
+.PHONY: all
+all: $(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) $(OBJS) -o $(NAME)
+
+.PHONY: clean
+clean:
+	$(RM) $(OBJS)
+
+.PHONY: fclean
+fclean: clean
+	$(RM) $(NAME)
+
+.PHONY: re
+re: fclean all
+
+

--- a/include/commands/CommandNick.hpp
+++ b/include/commands/CommandNick.hpp
@@ -23,11 +23,47 @@ class CommandNick : public ACommand {
   CommandNick& operator=(const CommandNick& other);
 
   bool validateNickName(IRCMessage& msg, IRCMessage& reply);
+  void announceNickChange(IRCMessage& reply);
 };
 
 #endif  // __COMMAND_NICK_HPP__
 
 /*
+https://www.rfc-editor.org/rfc/rfc1459#section-4.1.2
+4.1.2 Nick message
+
+      Command: NICK
+   Parameters: <nickname> [ <hopcount> ]
+
+   NICK message is used to give user a nickname or change the previous
+   one.  The <hopcount> parameter is only used by servers to indicate
+   how far away a nick is from its home server.  A local connection has
+   a hopcount of 0.  If supplied by a client, it must be ignored.
+
+   If a NICK message arrives at a server which already knows about an
+   identical nickname for another client, a nickname collision occurs.
+   As a result of a nickname collision, all instances of the nickname
+   are removed from the server's database, and a KILL command is issued
+   to remove the nickname from all other server's database. If the NICK
+   message causing the collision was a nickname change, then the
+   original (old) nick must be removed as well.
+
+   If the server recieves an identical NICK from a client which is
+   directly connected, it may issue an ERR_NICKCOLLISION to the local
+   client, drop the NICK command, and not generate any kills.
+
+   Numeric Replies:
+
+           ERR_NONICKNAMEGIVEN             ERR_ERRONEUSNICKNAME
+           ERR_NICKNAMEINUSE               ERR_NICKCOLLISION
+
+   Example:
+
+   NICK Wiz                        ; Introducing new nick "Wiz".
+
+   :WiZ NICK Kilroy                ; WiZ changed his nickname to Kilroy.
+
+
 // ニックネームが長過ぎる場合 o
 NICK a234567890
 :irc.example.net 432 nick1 a234567890 :Nickname too long, max. 9 characters

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -20,6 +20,9 @@ enable_testing()
 
 # ft_irc関連のソースをgoogleTestに追加 ############################################################################################
 file(GLOB_RECURSE LIB_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ../../src/*.cpp)
+# テスト用ライブラリを追加
+file(GLOB_RECURSE TEST_DATA_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ./lib/*.cpp)
+list(APPEND LIB_SRCS ${TEST_DATA_SRCS})
 
 # main.cを除外
 list(REMOVE_ITEM LIB_SRCS ../../src/main.cpp)
@@ -30,6 +33,7 @@ target_compile_definitions(libftirc PRIVATE UNIT_TEST)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -DUNIT_TEST=1")
 include_directories(
+  "${CMAKE_CURRENT_SOURCE_DIR}/lib"
   "${CMAKE_CURRENT_SOURCE_DIR}/../../include"
   "${CMAKE_CURRENT_SOURCE_DIR}/../../include/commands"
   # "${CMAKE_CURRENT_SOURCE_DIR}/build/_deps/googletest-src/googletest/include"

--- a/test/unit/lib/TestDataGenerator.cpp
+++ b/test/unit/lib/TestDataGenerator.cpp
@@ -1,0 +1,77 @@
+
+#include "TestDataGenerator.hpp"
+
+void TestDataGenerator::callCommand(RequestHandler &rh, Client *client,
+                                    const std::string &command) {
+  IRCMessage msg(client, command);
+  rh.handleCommand(msg);
+}
+
+void TestDataGenerator::makeUserData(IRCServer &server,
+                                     std::map<int, Client *> &clients,
+                                     RequestHandler &rh) {
+  clients[10] = new Client(10);
+  clients[11] = new Client(11);
+  clients[12] = new Client(12);
+  clients[13] = new Client(13);
+  clients[14] = new Client(14);
+  clients[15] = new Client(15);
+  server.addClient(clients[10]);
+  server.addClient(clients[11]);
+  server.addClient(clients[12]);
+  server.addClient(clients[13]);
+  server.addClient(clients[14]);
+  server.addClient(clients[15]);
+
+  callCommand(rh, clients[10], "USER user1 0 * :Real Name 1");
+  callCommand(rh, clients[10], "PASS pass123");
+  callCommand(rh, clients[10], "NICK nick1");
+  callCommand(rh, clients[10], "JOIN #ch1");
+  callCommand(rh, clients[10], "JOIN #ch2");
+  callCommand(rh, clients[10], "JOIN #ch3");
+
+  callCommand(rh, clients[11], "USER user2 0 * :Real Name 2");
+  callCommand(rh, clients[11], "PASS pass123");
+  callCommand(rh, clients[11], "NICK nick2");
+  callCommand(rh, clients[11], "JOIN #ch2");
+  callCommand(rh, clients[11], "JOIN #ch3");
+  callCommand(rh, clients[11], "JOIN #ch4");
+
+  callCommand(rh, clients[12], "USER user3 0 * :Real Name 3");
+  callCommand(rh, clients[12], "PASS pass123");
+  callCommand(rh, clients[12], "NICK nick3");
+  callCommand(rh, clients[12], "JOIN #ch3");
+  callCommand(rh, clients[12], "JOIN #ch4");
+  callCommand(rh, clients[12], "JOIN #ch5");
+
+  callCommand(rh, clients[13], "USER user4 0 * :Real Name 4");
+  callCommand(rh, clients[13], "PASS pass123");
+  callCommand(rh, clients[13], "NICK nick4");
+  callCommand(rh, clients[13], "JOIN #ch4");
+  callCommand(rh, clients[13], "JOIN #ch5");
+  callCommand(rh, clients[13], "JOIN #ch1");
+
+  // 未ログイン（ニックネームあり）
+  callCommand(rh, clients[14], "USER user5 0 * :Real Name 5");
+  // callCommand(rh, clients[14], "PASS pass123");
+  callCommand(rh, clients[14], "NICK nick5");
+
+  // 未ログイン（ニックネームなし）
+  callCommand(rh, clients[15], "USER user6 0 * :Real Name 6");
+  callCommand(rh, clients[15], "PASS pass123");
+  // callCommand(rh, clients[15], "NICK nick6");
+
+  clients[10]->consumeSendingMsg(100000);  // 送信メッセージをクリア
+  clients[11]->consumeSendingMsg(100000);  // 送信メッセージをクリア
+  clients[12]->consumeSendingMsg(100000);  // 送信メッセージをクリア
+  clients[13]->consumeSendingMsg(100000);  // 送信メッセージをクリア
+  clients[14]->consumeSendingMsg(100000);  // 送信メッセージをクリア
+  clients[15]->consumeSendingMsg(100000);  // 送信メッセージをクリア
+
+  clients[10]->popReceivingMsg();  // 受信メッセージをクリア
+  clients[11]->popReceivingMsg();  // 受信メッセージをクリア
+  clients[12]->popReceivingMsg();  // 受信メッセージをクリア
+  clients[13]->popReceivingMsg();  // 受信メッセージをクリア
+  clients[14]->popReceivingMsg();  // 受信メッセージをクリア
+  clients[15]->popReceivingMsg();  // 受信メッセージをクリア
+}

--- a/test/unit/lib/TestDataGenerator.hpp
+++ b/test/unit/lib/TestDataGenerator.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "IRCServer.hpp"
+#include "RequestHandler.hpp"
+
+class TestDataGenerator {
+ public:
+  static void callCommand(RequestHandler &rh, Client *client,
+                          const std::string &command);
+
+  static void makeUserData(IRCServer &server, std::map<int, Client *> &clients,
+                           RequestHandler &rh);
+
+ private:
+  TestDataGenerator();
+  ~TestDataGenerator();
+};

--- a/test/unit/src/Commands/TestCommandPrivMsg.cpp
+++ b/test/unit/src/Commands/TestCommandPrivMsg.cpp
@@ -1,88 +1,13 @@
 #include <gtest/gtest.h>
 
-#include "IRCServer.hpp"
-#include "RequestHandler.hpp"
-
-static void callCommand(RequestHandler &rh, Client *client,
-                        const std::string &command) {
-  IRCMessage msg(client, command);
-  rh.handleCommand(msg);
-}
-
-static void makeUserData(IRCServer &server, std::map<int, Client *> &clients,
-                         RequestHandler &rh) {
-  clients[10] = new Client(10);
-  clients[11] = new Client(11);
-  clients[12] = new Client(12);
-  clients[13] = new Client(13);
-  clients[14] = new Client(14);
-  clients[15] = new Client(15);
-  server.addClient(clients[10]);
-  server.addClient(clients[11]);
-  server.addClient(clients[12]);
-  server.addClient(clients[13]);
-  server.addClient(clients[14]);
-  server.addClient(clients[15]);
-
-  callCommand(rh, clients[10], "USER user1 0 * :Real Name 1");
-  callCommand(rh, clients[10], "PASS pass123");
-  callCommand(rh, clients[10], "NICK nick1");
-  callCommand(rh, clients[10], "JOIN #ch1");
-  callCommand(rh, clients[10], "JOIN #ch2");
-  callCommand(rh, clients[10], "JOIN #ch3");
-
-  callCommand(rh, clients[11], "USER user2 0 * :Real Name 2");
-  callCommand(rh, clients[11], "PASS pass123");
-  callCommand(rh, clients[11], "NICK nick2");
-  callCommand(rh, clients[11], "JOIN #ch2");
-  callCommand(rh, clients[11], "JOIN #ch3");
-  callCommand(rh, clients[11], "JOIN #ch4");
-
-  callCommand(rh, clients[12], "USER user3 0 * :Real Name 3");
-  callCommand(rh, clients[12], "PASS pass123");
-  callCommand(rh, clients[12], "NICK nick3");
-  callCommand(rh, clients[12], "JOIN #ch3");
-  callCommand(rh, clients[12], "JOIN #ch4");
-  callCommand(rh, clients[12], "JOIN #ch5");
-
-  callCommand(rh, clients[13], "USER user4 0 * :Real Name 4");
-  callCommand(rh, clients[13], "PASS pass123");
-  callCommand(rh, clients[13], "NICK nick4");
-  callCommand(rh, clients[13], "JOIN #ch4");
-  callCommand(rh, clients[13], "JOIN #ch5");
-  callCommand(rh, clients[13], "JOIN #ch1");
-
-  // 未ログイン（ニックネームあり）
-  callCommand(rh, clients[14], "USER user5 0 * :Real Name 5");
-  // callCommand(rh, clients[14], "PASS pass123");
-  callCommand(rh, clients[14], "NICK nick5");
-
-  // 未ログイン（ニックネームなし）
-  callCommand(rh, clients[15], "USER user6 0 * :Real Name 6");
-  // callCommand(rh, clients[15], "PASS pass123");
-  // callCommand(rh, clients[15], "NICK nick6");
-
-  clients[10]->consumeSendingMsg(100000);  // 送信メッセージをクリア
-  clients[11]->consumeSendingMsg(100000);  // 送信メッセージをクリア
-  clients[12]->consumeSendingMsg(100000);  // 送信メッセージをクリア
-  clients[13]->consumeSendingMsg(100000);  // 送信メッセージをクリア
-  clients[14]->consumeSendingMsg(100000);  // 送信メッセージをクリア
-  clients[15]->consumeSendingMsg(100000);  // 送信メッセージをクリア
-
-  clients[10]->popReceivingMsg();  // 受信メッセージをクリア
-  clients[11]->popReceivingMsg();  // 受信メッセージをクリア
-  clients[12]->popReceivingMsg();  // 受信メッセージをクリア
-  clients[13]->popReceivingMsg();  // 受信メッセージをクリア
-  clients[14]->popReceivingMsg();  // 受信メッセージをクリア
-  clients[15]->popReceivingMsg();  // 受信メッセージをクリア
-}
+#include "TestDataGenerator.hpp"
 
 // 通常
 TEST(CommandPrivMsg, nomal1) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
   RequestHandler requestHandler(&server);
-  makeUserData(server, clients, requestHandler);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "PRIVMSG nick2 hello";
   std::string expected = ":nick1!~user1@localhost PRIVMSG nick2 :hello";
@@ -101,7 +26,7 @@ TEST(CommandPrivMsg, nomal2) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
   RequestHandler requestHandler(&server);
-  makeUserData(server, clients, requestHandler);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "PRIVMSG nick2 :";
   std::string expected = ":nick1!~user1@localhost PRIVMSG nick2 :";
@@ -120,7 +45,7 @@ TEST(CommandPrivMsg, nomal3) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
   RequestHandler requestHandler(&server);
-  makeUserData(server, clients, requestHandler);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "PRIVMSG nick2 :寿司🍣 酒池肉林🍺🍖 Hello World!";
   std::string expected =
@@ -140,7 +65,7 @@ TEST(CommandPrivMsg, nomal4) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
   RequestHandler requestHandler(&server);
-  makeUserData(server, clients, requestHandler);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr =
       "PRIVMSG nick2 "
@@ -175,7 +100,7 @@ TEST(CommandPrivMsg, nomal5) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
   RequestHandler requestHandler(&server);
-  makeUserData(server, clients, requestHandler);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "PRIVMSG nick1 hello";
   std::string expected = ":nick1!~user1@localhost PRIVMSG nick1 :hello";
@@ -194,7 +119,7 @@ TEST(CommandPrivMsg, not_registered1) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
   RequestHandler requestHandler(&server);
-  makeUserData(server, clients, requestHandler);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   clients[10]->setIsRegistered(false);  // 未ログイン状態にする
   clients[10]->setNickName("");         // ニックネームを空にする
@@ -216,7 +141,7 @@ TEST(CommandPrivMsg, not_registered2) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
   RequestHandler requestHandler(&server);
-  makeUserData(server, clients, requestHandler);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   clients[10]->setIsRegistered(false);  // 未ログイン状態にする
 
@@ -237,7 +162,7 @@ TEST(CommandPrivMsg, no_args) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
   RequestHandler requestHandler(&server);
-  makeUserData(server, clients, requestHandler);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "PRIVMSG";
   std::string expected =
@@ -257,7 +182,7 @@ TEST(CommandPrivMsg, one_args) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
   RequestHandler requestHandler(&server);
-  makeUserData(server, clients, requestHandler);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "PRIVMSG nick2";
   std::string expected = ":irc.example.net 412 nick1 :No text to send";
@@ -276,7 +201,7 @@ TEST(CommandPrivMsg, over_args) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
   RequestHandler requestHandler(&server);
-  makeUserData(server, clients, requestHandler);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "PRIVMSG nick2 a b";
   std::string expected =
@@ -296,7 +221,7 @@ TEST(CommandPrivMsg, not_exist) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
   RequestHandler requestHandler(&server);
-  makeUserData(server, clients, requestHandler);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "PRIVMSG xxx hello";
   std::string expected = ":irc.example.net 401 nick1 xxx :No such nick/channel";
@@ -317,7 +242,7 @@ TEST(CommandPrivMsg, nomal_multi1) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
   RequestHandler requestHandler(&server);
-  makeUserData(server, clients, requestHandler);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "PRIVMSG nick2,nick3,#ch1,#ch2,#ch5 hello";
   IRCMessage msg(clients[10], msgStr);
@@ -344,7 +269,7 @@ TEST(CommandPrivMsg, error_multi1) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
   RequestHandler requestHandler(&server);
-  makeUserData(server, clients, requestHandler);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "PRIVMSG nick2,xxx,#ch1,#chx,nick5,nick6 hello";
   IRCMessage msg(clients[10], msgStr);

--- a/test/unit/src/Commands/testCommandNick.cpp
+++ b/test/unit/src/Commands/testCommandNick.cpp
@@ -19,6 +19,11 @@ TEST(CommandNick, nomal) {
   EXPECT_EQ(server.getClients().at(10)->getNickName(), expected);
   EXPECT_EQ(clients[10]->getSendingMsg(), expected_reply + "\r\n");
   // TODO チャンネルの他のユーザーへの通知をテストする
+  EXPECT_EQ(clients[11]->getSendingMsg(), expected_reply + "\r\n");
+  EXPECT_EQ(clients[12]->getSendingMsg(), expected_reply + "\r\n");
+  EXPECT_EQ(clients[13]->getSendingMsg(), expected_reply + "\r\n");
+  EXPECT_EQ(clients[14]->getSendingMsg(), "");
+  EXPECT_EQ(clients[15]->getSendingMsg(), "");
 }
 
 // ニックネームが長過ぎる

--- a/test/unit/src/Commands/testCommandNick.cpp
+++ b/test/unit/src/Commands/testCommandNick.cpp
@@ -1,40 +1,19 @@
 #include <gtest/gtest.h>
 
-#include "IRCServer.hpp"
-#include "RequestHandler.hpp"
-
-static void makeUserData(IRCServer &server, std::map<int, Client *> &clients) {
-  clients[10] = new Client(10);
-  clients[10]->setNickName("nick1");
-  clients[10]->setUserName("user1");
-
-  clients[11] = new Client(11);
-  clients[11]->setNickName("nick2");
-  clients[11]->setUserName("user2");
-
-  clients[12] = new Client(12);
-  clients[12]->setNickName("nick3");
-  clients[12]->setUserName("user3");
-
-  server.addClient(clients[10]);
-  server.addClient(clients[11]);
-  server.addClient(clients[12]);
-  // TODO 他のユーザーをチャンネルに参加させる
-}
+#include "TestDataGenerator.hpp"
 
 // 通常
 TEST(CommandNick, nomal) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
-  makeUserData(server, clients);
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "NICK a23456789";
   std::string expected = "a23456789";
   std::string expected_reply = ":nick1!~user1@localhost NICK :a23456789";
 
   IRCMessage msg(clients[10], msgStr);
-
-  RequestHandler requestHandler(&server);
   requestHandler.handleCommand(msg);
 
   EXPECT_EQ(server.getClients().at(10)->getNickName(), expected);
@@ -46,7 +25,8 @@ TEST(CommandNick, nomal) {
 TEST(CommandNick, too_long) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
-  makeUserData(server, clients);
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "NICK a234567890";
   std::string expected = "nick1";
@@ -55,8 +35,6 @@ TEST(CommandNick, too_long) {
       "characters";
 
   IRCMessage msg(clients[10], msgStr);
-
-  RequestHandler requestHandler(&server);
   requestHandler.handleCommand(msg);
 
   // ニックネームは変更されない
@@ -72,15 +50,14 @@ TEST(CommandNick, too_long) {
 TEST(CommandNick, same_nickname) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
-  makeUserData(server, clients);
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "NICK nick1";
   std::string expected = "nick1";
   std::string expected_reply = "";
 
   IRCMessage msg(clients[10], msgStr);
-
-  RequestHandler requestHandler(&server);
   requestHandler.handleCommand(msg);
 
   // ニックネームは変更されない
@@ -96,7 +73,8 @@ TEST(CommandNick, same_nickname) {
 TEST(CommandNick, no_args) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
-  makeUserData(server, clients);
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "NICK ";
   std::string expected = "nick1";
@@ -104,8 +82,6 @@ TEST(CommandNick, no_args) {
       ":irc.example.net 461 nick1 NICK :Not enough parameters";
 
   IRCMessage msg(clients[10], msgStr);
-
-  RequestHandler requestHandler(&server);
   requestHandler.handleCommand(msg);
 
   // ニックネームは変更されない
@@ -121,7 +97,8 @@ TEST(CommandNick, no_args) {
 TEST(CommandNick, dup_nickname) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
-  makeUserData(server, clients);
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "NICK nick2";
   std::string expected = "nick1";
@@ -129,8 +106,6 @@ TEST(CommandNick, dup_nickname) {
       ":irc.example.net 433 nick1 nick2 :Nickname already in use";
 
   IRCMessage msg(clients[10], msgStr);
-
-  RequestHandler requestHandler(&server);
   requestHandler.handleCommand(msg);
 
   // ニックネームは変更されない
@@ -146,7 +121,8 @@ TEST(CommandNick, dup_nickname) {
 TEST(CommandNick, invalid_nickname1) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
-  makeUserData(server, clients);
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "NICK 1nick";
   std::string expected = "nick1";
@@ -154,8 +130,6 @@ TEST(CommandNick, invalid_nickname1) {
       ":irc.example.net 432 nick1 1nick :Erroneous nickname";
 
   IRCMessage msg(clients[10], msgStr);
-
-  RequestHandler requestHandler(&server);
   requestHandler.handleCommand(msg);
 
   // ニックネームは変更されない
@@ -171,7 +145,8 @@ TEST(CommandNick, invalid_nickname1) {
 TEST(CommandNick, invalid_nickname2) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
-  makeUserData(server, clients);
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "NICK nick@";
   std::string expected = "nick1";
@@ -179,8 +154,6 @@ TEST(CommandNick, invalid_nickname2) {
       ":irc.example.net 432 nick1 nick@ :Erroneous nickname";
 
   IRCMessage msg(clients[10], msgStr);
-
-  RequestHandler requestHandler(&server);
   requestHandler.handleCommand(msg);
 
   // ニックネームは変更されない
@@ -196,7 +169,8 @@ TEST(CommandNick, invalid_nickname2) {
 TEST(CommandNick, invalid_nickname3) {
   IRCServer server("6677", "pass123");
   std::map<int, Client *> clients;
-  makeUserData(server, clients);
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
 
   std::string msgStr = "NICK #ch";
   std::string expected = "nick1";
@@ -204,8 +178,6 @@ TEST(CommandNick, invalid_nickname3) {
       ":irc.example.net 432 nick1 #ch :Erroneous nickname";
 
   IRCMessage msg(clients[10], msgStr);
-
-  RequestHandler requestHandler(&server);
   requestHandler.handleCommand(msg);
 
   // ニックネームは変更されない

--- a/test/unit/src/Commands/testCommandNick.cpp
+++ b/test/unit/src/Commands/testCommandNick.cpp
@@ -26,6 +26,23 @@ TEST(CommandNick, nomal) {
   EXPECT_EQ(clients[15]->getSendingMsg(), "");
 }
 
+// 通常(未ログインの場合、返信しない)
+TEST(CommandNick, nomal2) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "NICK a23456789";
+  std::string expected = "a23456789";
+
+  IRCMessage msg(clients[14], msgStr);
+  requestHandler.handleCommand(msg);
+
+  EXPECT_EQ(server.getClients().at(14)->getNickName(), expected);
+  EXPECT_EQ(clients[10]->getSendingMsg(), "");
+}
+
 // ニックネームが長過ぎる
 TEST(CommandNick, too_long) {
   IRCServer server("6677", "pass123");


### PR DESCRIPTION
## ニックネームの変更を他のユーザーに通知するようにしました
NICKの場合、返信メッセージ```:nick1!~user1@localhost NICK :nick2```の
プレフィックス```:nick1!~user1@localhost```は変更前の値を使う必要があり、
ACommandのpushResponse(with command)の処理は使えません。


## テスト用データを作成するクラスを作りました
```test/unit/lib/TestDataGenerator.cpp```
このクラスはキレイに保つ必要なないので、
自分用の欲しいテストデータがあれば、
makeUserData2()
makeUserData3()
とか、適当に作って大丈夫です。


## Make時のエラーについて
ちょっと関係ない話なのですが、僕の環境でmakeすると、下記のようなワーニングが出ます。
この現象は僕だけですか？何度やっても同じワーニングがでます。
```
$ make re
(省略)
<-------- ./ircserv linked. -------------------------->
<-------- ./ircserv permission changed. -------------->
######### ./ircserv compile finished! #################
make: warning:  Clock skew detected.  Your build may be incomplete.
```
プルリクにいれた、前のシンプルなバージョンのMakefileだと、ワーニングは出ません。
```
$ make -f Makefile.old re
```
あんまり気にしなくても良さそうですが、なんか”Your build may be incomplete.”と言われると気持ち悪いなと。
jinさんの環境だとワーニングは出ないですか？