### PR TITLE
KICKコマンド実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ SRCS := src/main.cpp src/IRCServer.cpp src/Client.cpp src/Channel.cpp\
 		src/commands/CommandJoin.cpp src/commands/CommandTopic.cpp \
 		src/commands/CommandMode.cpp src/commands/CommandInvite.cpp \
 		src/commands/CommandPrivMsg.cpp \
+		src/commands/CommandKick.cpp \
 		src/commands/CommandBroadCast.cpp
 OBJS = $(patsubst $(SRCS_ROOT_DIR)/%.cpp,$(OBJS_ROOT_DIR)/%.o,$(SRCS))
 

--- a/include/commands/CommandKick.hpp
+++ b/include/commands/CommandKick.hpp
@@ -1,0 +1,115 @@
+#pragma once
+#ifndef __COMMAND_KICK_HPP__
+#define __COMMAND_KICK_HPP__
+
+#include "ACommand.hpp"
+
+class CommandKick : public ACommand {
+ public:
+  // Orthodox Canonical Form
+  CommandKick(IRCServer* server);
+  ~CommandKick();
+
+  // Member functions
+  void execute(IRCMessage& msg);
+
+ private:
+  CommandKick();
+  CommandKick(const CommandKick& other);
+  CommandKick& operator=(const CommandKick& other);
+
+  bool validateKick(IRCMessage& msg);
+  Channel* getAndValidateChannel(IRCMessage& msg, const std::string& ch_str);
+  Client* getAndValidateClient(IRCMessage& msg, Channel* channel,
+                               const std::string& nick);
+
+  void kickMembers(IRCMessage& msg, Channel* channel,
+                   const std::vector<std::string> nicks);
+};
+
+#endif  // __COMMAND_KICK_HPP__
+
+/*
+https://www.rfc-editor.org/rfc/rfc1459#section-4.2.8
+4.2.8 Kick command
+
+      Command: KICK
+   Parameters: <channel> <user> [<comment>]
+
+   The KICK command can be  used  to  forcibly  remove  a  user  from  a
+   channel.   It  'kicks  them  out'  of the channel (forced PART).
+   Only a channel operator may kick another user out of a  channel.
+   Each  server that  receives  a KICK message checks that it is valid
+   (ie the sender is actually a  channel  operator)  before  removing
+   the  victim  from  the channel.
+
+   Numeric Replies:
+
+           ERR_NEEDMOREPARAMS              ERR_NOSUCHCHANNEL
+           ERR_BADCHANMASK                 ERR_CHANOPRIVSNEEDED
+           ERR_NOTONCHANNEL
+
+   Examples:
+
+KICK &Melbourne Matthew         ; Kick Matthew from &Melbourne
+
+KICK #Finnish John :Speaking English
+                                ; Kick John from #Finnish using
+                                "Speaking English" as the reason
+                                (comment).
+
+:WiZ KICK #Finnish John         ; KICK message from WiZ to remove John
+                                from channel #Finnish
+
+NOTE:
+     It is possible to extend the KICK command parameters to the
+following:
+
+<channel>{,<channel>} <user>{,<user>} [<comment>]
+
+// 通常（コメントなし）
+KICK #ch nick2
+:nick1!~a@localhost KICK #ch nick2 :nick1
+
+// 通常(コメントあり)
+KICK #ch1 nick2 bye
+:nick1!~a@localhost KICK #ch1 nick2 :bye
+
+// ログインしていない
+:irc.example.net 451 * :Connection not registered
+
+// 引数が足りない
+// 引数が多い
+KICK #ch1 nick2 a b
+:irc.example.net 461 nick1 KICK :Syntax error
+
+// チャンネルに所属していない
+KICK #ch1 nick2
+:irc.example.net 442 nick1 #ch1 :You are not on that channel
+
+//　権限がない（チャンネルのオペレーターではない）
+KICK #ch1 nick1
+:irc.example.net 482 nick2 #ch1 :Your privileges are too low
+
+// チャンネルがない
+KICK #chx nick3 bye
+:irc.example.net 403 nick1 #chx :No such channel
+// ニックネームがない
+KICK #ch1 nickx bye
+:irc.example.net 401 nick1 nickx :No such nick or channel name
+
+// ユーザーがチャンネルにいない
+KICK #ch2 nick3 bye
+:irc.example.net 441 nick1 nick3 #ch2 :They aren't on that channel
+
+// 自分自身はKICKできる？ 可能
+// operatorをKICKできる？　可能
+
+
+           ERR_NEEDMOREPARAMS 461
+        ERR_NOSUCHCHANNEL 403
+           ERR_BADCHANMASK
+          ERR_CHANOPRIVSNEEDED 482
+           ERR_NOTONCHANNEL 442
+
+*/

--- a/include/commands/CommandKick.hpp
+++ b/include/commands/CommandKick.hpp
@@ -104,12 +104,4 @@ KICK #ch2 nick3 bye
 
 // 自分自身はKICKできる？ 可能
 // operatorをKICKできる？　可能
-
-
-           ERR_NEEDMOREPARAMS 461
-        ERR_NOSUCHCHANNEL 403
-           ERR_BADCHANMASK
-          ERR_CHANOPRIVSNEEDED 482
-           ERR_NOTONCHANNEL 442
-
 */

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -18,7 +18,6 @@ Channel::Channel(const std::string& name, Client* client)
   chanop_.insert(client);
 }
 
-
 // Getters
 const std::string& Channel::getName() const {
   return name_;
@@ -77,7 +76,6 @@ bool Channel::isInvited(Client* client) const {
   return false;
 }
 
-
 // Setters
 bool Channel::setTopic(const std::string& topic) {
   topic_ = topic;
@@ -115,6 +113,7 @@ bool Channel::addMember(Client* client) {
     return false;
   }
   member_.insert(client);
+  client->addJoinedChannel(this);
   return true;
 }
 
@@ -135,10 +134,11 @@ bool Channel::addInvited(Client* client) {
 
 bool Channel::removeMember(Client* client) {
   if (member_.find(client) == member_.end()) {
-    member_.erase(client);
-    return true;
+    return false;
   }
-  return false;
+  member_.erase(client);
+  client->removeJoinedChannel(name_);
+  return true;
 }
 
 bool Channel::removeChanop(Client* client) {

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -88,11 +88,19 @@ void Client::setPassword(const std::string& password) {
 //   isCapabilityNegotiating_ = isCapabilityNegotiating;
 // }
 
+// Channel::member_と整合性をとるため
+// bool Channel::addMember(Client* client)を呼ぶと、
+// 内部でaddJoinedChannelも読んでいるため
+// 個別にこの関数を呼ぶ必要はない
 void Client::addJoinedChannel(Channel* channel) {
   std::string channelName = channel->getName();
   joinedChannels_[channelName] = channel;
 }
 
+// Channel::member_と整合性をとるため
+// bool Channel::removeMember(Client* client)を呼ぶと、
+// 内部でremoveJoinedChannelも読んでいるため
+// 個別にこの関数を呼ぶ必要はない
 void Client::removeJoinedChannel(const std::string& channelName) {
   joinedChannels_.erase(channelName);
 }

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -2,15 +2,16 @@
 
 #include "ACommand.hpp"
 #include "CommandBroadCast.hpp"
+#include "CommandInvite.hpp"
+#include "CommandJoin.hpp"
+#include "CommandKick.hpp"
+#include "CommandMode.hpp"
 #include "CommandNick.hpp"
 #include "CommandPass.hpp"
 #include "CommandPing.hpp"
-#include "CommandMode.hpp"
 #include "CommandPrivMsg.hpp"
-#include "CommandUser.hpp"
-#include "CommandJoin.hpp"
-#include "CommandInvite.hpp"
 #include "CommandTopic.hpp"
+#include "CommandUser.hpp"
 #include "IRCLogger.hpp"
 #include "IRCParser.hpp"
 #include "IRCServer.hpp"
@@ -27,6 +28,7 @@ RequestHandler::RequestHandler(IRCServer* server) : server_(server) {
   commands_["TOPIC"] = new CommandTopic(server_);
   commands_["MODE"] = new CommandMode(server_);
   commands_["PRIVMSG"] = new CommandPrivMsg(server_);
+  commands_["KICK"] = new CommandKick(server_);
   // commands_["PART"] = new CommandPart(server_);
   commands_["PING"] = new CommandPing(server_);
   commands_["BROADCAST"] = new CommandBroadCast(server_);
@@ -52,7 +54,6 @@ RequestHandler& RequestHandler::operator=(const RequestHandler& other) {
   commands_ = other.commands_;
   return *this;
 }
-
 
 // Member functions
 void RequestHandler::handleCommand(IRCMessage& msg) {

--- a/src/commands/CommandJoin.cpp
+++ b/src/commands/CommandJoin.cpp
@@ -40,7 +40,6 @@ void CommandJoin::execute(IRCMessage& msg) {
       return;
     }
     channel->addMember(from);
-    from->addJoinedChannel(channel);
     reply.setRaw(":" + from->getUserPrefix() + " JOIN " + channelName);
     pushResponse(reply);
   }

--- a/src/commands/CommandKick.cpp
+++ b/src/commands/CommandKick.cpp
@@ -1,0 +1,122 @@
+#include "CommandKick.hpp"
+
+#include "Utils.hpp"
+
+CommandKick::CommandKick(IRCServer* server) : ACommand(server, "KICK") {}
+
+CommandKick::~CommandKick() {}
+
+bool CommandKick::validateKick(IRCMessage& msg) {
+  // ログインしていない
+  if (!checkIsRegistered(msg)) {
+    return false;
+  }
+  // 引数が足りない
+  if (!checkParamNum(msg, 2)) {
+    return false;
+  }
+  // 　引数が多い
+  if (msg.getParams().size() > 3) {
+    IRCMessage reply(msg.getFrom(), msg.getFrom());
+    reply.setResCode(ERR_NEEDMOREPARAMS);
+    pushResponse(reply);
+    return false;
+  }
+  return true;
+}
+
+Channel* CommandKick::getAndValidateChannel(IRCMessage& msg,
+                                            const std::string& ch_str) {
+  Client* from = msg.getFrom();
+  IRCMessage reply(from, from);
+  reply.addParam(ch_str);
+
+  Channel* channel = server_->getChannel(ch_str);
+  // チャンネルがない
+  if (channel == NULL) {
+    reply.setResCode(ERR_NOSUCHCHANNEL);
+    pushResponse(reply);
+    return NULL;
+  }
+  // 実行者がチャンネルに所属していない
+  if (!channel->isMember(from)) {
+    reply.setResCode(ERR_NOTONCHANNEL);
+    pushResponse(reply);
+    return NULL;
+  }
+  // 権限がない（チャンネルのオペレーターではない）
+  if (!channel->isChanop(from)) {
+    reply.setResCode(ERR_CHANOPRIVSNEEDED);
+    pushResponse(reply);
+    return NULL;
+  }
+  return channel;
+}
+
+Client* CommandKick::getAndValidateClient(IRCMessage& msg, Channel* channel,
+                                          const std::string& nick) {
+  IRCMessage reply(msg.getFrom(), msg.getFrom());
+  reply.addParam(nick);
+  reply.addParam(channel->getName());
+
+  Client* client = server_->getClient(nick);
+  // ニックネームが存在しない
+  if (client == NULL) {
+    reply.setResCode(ERR_NOSUCHNICK);
+    pushResponse(reply);
+    return NULL;
+  }
+  // 対象者がチャンネルに参加していない
+  if (!channel->isMember(client)) {
+    reply.setResCode(ERR_USERNOTINCHANNEL);
+    pushResponse(reply);
+    return NULL;
+  }
+  return client;
+}
+
+void CommandKick::kickMembers(IRCMessage& msg, Channel* channel,
+                              const std::vector<std::string> nicks) {
+  for (std::vector<std::string>::const_iterator nick = nicks.begin();
+       nick != nicks.end(); ++nick) {
+    Client* client = getAndValidateClient(msg, channel, *nick);
+    if (client == NULL) {
+      continue;
+    }
+    // メッセージ作成
+    IRCMessage reply(msg.getFrom(), msg.getFrom());
+    reply.setCommand("KICK");
+    reply.addParam(channel->getName());
+    reply.addParam(client->getNickName());
+    if ((msg.getParams().size() == 3)) {
+      reply.addParam(":" + msg.getParam(2));
+    } else {
+      reply.addParam(":" + msg.getFrom()->getNickName());
+    }
+    // チャンネル全員に通知
+    for (std::set<Client*>::const_iterator it = channel->getMember().begin();
+         it != channel->getMember().end(); ++it) {
+      reply.setTo(*it);
+      pushResponse(reply);
+    }
+    // チャンネルからユーザー削除
+    channel->removeMember(client);
+  }
+}
+
+void CommandKick::execute(IRCMessage& msg) {
+  if (!validateKick(msg)) {
+    return;
+  }
+
+  std::vector<std::string> ch_names = Utils::split(msg.getParam(0), ",");
+  std::vector<std::string> nicks = Utils::split(msg.getParam(1), ",");
+  for (std::vector<std::string>::const_iterator it = ch_names.begin();
+       it != ch_names.end(); ++it) {
+    Channel* channel = getAndValidateChannel(msg, *it);
+    if (channel == NULL) {
+      continue;
+    }
+    kickMembers(msg, channel, nicks);
+  }
+}

--- a/test/unit/src/Commands/TestCommandKick.cpp
+++ b/test/unit/src/Commands/TestCommandKick.cpp
@@ -15,7 +15,7 @@ TEST(CommandKick, nomal1) {
   IRCMessage msg(clients[10], msgStr);
   requestHandler.handleCommand(msg);
 
-  // メンバーが見つからない
+  // KICKされていることを確認
   std::set<Client *> member = server.getChannel("#ch3")->getMember();
   EXPECT_EQ(member.find(clients[11]), member.end());
 
@@ -40,7 +40,7 @@ TEST(CommandKick, nomal2) {
   IRCMessage msg(clients[10], msgStr);
   requestHandler.handleCommand(msg);
 
-  // メンバーが見つからない
+  // KICKされていることを確認
   std::set<Client *> member = server.getChannel("#ch3")->getMember();
   EXPECT_EQ(member.find(clients[11]), member.end());
 
@@ -65,6 +65,9 @@ TEST(CommandKick, not_registered) {
   IRCMessage msg(clients[15], msgStr);
   requestHandler.handleCommand(msg);
 
+  // KICKされていないことを確認
+  std::set<Client *> member = server.getChannel("#ch3")->getMember();
+  EXPECT_NE(member.find(clients[11]), member.end());
   // エラーメッセージ
   EXPECT_EQ(clients[15]->getSendingMsg(), expected + "\r\n");
   // 何も送信されない
@@ -109,6 +112,9 @@ TEST(CommandKick, arg1) {
   IRCMessage msg(clients[10], msgStr);
   requestHandler.handleCommand(msg);
 
+  // KICKされない
+  std::set<Client *> member = server.getChannel("#ch3")->getMember();
+  EXPECT_NE(member.find(clients[11]), member.end());
   // エラーメッセージ
   EXPECT_EQ(clients[10]->getSendingMsg(), expected + "\r\n");
   // 何も送信されない
@@ -130,6 +136,9 @@ TEST(CommandKick, arg4) {
   IRCMessage msg(clients[10], msgStr);
   requestHandler.handleCommand(msg);
 
+  // KICKされていないことを
+  std::set<Client *> member = server.getChannel("#ch3")->getMember();
+  EXPECT_NE(member.find(clients[11]), member.end());
   // エラーメッセージ
   EXPECT_EQ(clients[10]->getSendingMsg(), expected + "\r\n");
   // 何も送信されない
@@ -173,6 +182,9 @@ TEST(CommandKick, I_am_not_member) {
   IRCMessage msg(clients[10], msgStr);
   requestHandler.handleCommand(msg);
 
+  // KICKされていないことを確認
+  std::set<Client *> member = server.getChannel("#ch4")->getMember();
+  EXPECT_NE(member.find(clients[11]), member.end());
   // エラーメッセージ
   EXPECT_EQ(clients[10]->getSendingMsg(), expected + "\r\n");
   // 何も送信されない
@@ -194,6 +206,9 @@ TEST(CommandKick, no_operator) {
   IRCMessage msg(clients[11], msgStr);
   requestHandler.handleCommand(msg);
 
+  // KICKされていないことを確認
+  std::set<Client *> member = server.getChannel("#ch3")->getMember();
+  EXPECT_NE(member.find(clients[11]), member.end());
   // エラーメッセージ
   EXPECT_EQ(clients[11]->getSendingMsg(), expected + "\r\n");
   // 何も送信されない
@@ -259,10 +274,20 @@ TEST(CommandKick, nomal_multip1) {
   IRCMessage msg(clients[10], msgStr);
   requestHandler.handleCommand(msg);
 
-  // メンバーが見つからない
-  std::set<Client *> member = server.getChannel("#ch3")->getMember();
-  EXPECT_EQ(member.find(clients[11]), member.end());
+  // #ch2からKICKされている
+  std::set<Client *> member2 = server.getChannel("#ch2")->getMember();
+  EXPECT_EQ(member2.find(clients[11]), member2.end());
+  // #ch3からKICKされている
+  std::set<Client *> member3 = server.getChannel("#ch3")->getMember();
+  EXPECT_EQ(member3.find(clients[11]), member3.end());
+  EXPECT_EQ(member3.find(clients[12]), member3.end());
+  // #ch4はKICKされていないことを確認
+  std::set<Client *> member4 = server.getChannel("#ch4")->getMember();
+  EXPECT_NE(member4.find(clients[11]), member4.end());
+  EXPECT_NE(member4.find(clients[12]), member4.end());
+  EXPECT_NE(member4.find(clients[13]), member4.end());
 
+  // 実行者の通知
   EXPECT_EQ(
       clients[10]->getSendingMsg(),
       ":nick1!~user1@localhost KICK #ch2 nick2 :bye bye\r\n"

--- a/test/unit/src/Commands/TestCommandKick.cpp
+++ b/test/unit/src/Commands/TestCommandKick.cpp
@@ -1,0 +1,245 @@
+#include <gtest/gtest.h>
+
+#include "TestDataGenerator.hpp"
+
+// 通常（コメントあり）
+TEST(CommandKick, nomal1) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "KICK #ch3 nick2 :bye bye";
+  std::string expected = ":nick1!~user1@localhost KICK #ch3 nick2 :bye bye";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  // メンバーが見つからない
+  std::set<Client *> member = server.getChannel("#ch3")->getMember();
+  EXPECT_EQ(member.find(clients[11]), member.end());
+
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected + "\r\n");
+  // TODO チャンネルの他のユーザーへの通知をテストする
+  EXPECT_EQ(clients[11]->getSendingMsg(), expected + "\r\n");
+  EXPECT_EQ(clients[12]->getSendingMsg(), expected + "\r\n");
+
+  EXPECT_EQ(clients[13]->getSendingMsg(), "");
+}
+
+// 通常(コメントなし)
+TEST(CommandKick, nomal2) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "KICK #ch3 nick2";
+  std::string expected = ":nick1!~user1@localhost KICK #ch3 nick2 :nick1";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  // メンバーが見つからない
+  std::set<Client *> member = server.getChannel("#ch3")->getMember();
+  EXPECT_EQ(member.find(clients[11]), member.end());
+
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected + "\r\n");
+  // TODO チャンネルの他のユーザーへの通知をテストする
+  EXPECT_EQ(clients[11]->getSendingMsg(), expected + "\r\n");
+  EXPECT_EQ(clients[12]->getSendingMsg(), expected + "\r\n");
+
+  EXPECT_EQ(clients[13]->getSendingMsg(), "");
+}
+
+// ログインしていない
+TEST(CommandKick, not_registered) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "KICK #ch3 nick2";
+  std::string expected = ":irc.example.net 451 * :You have not registered";
+
+  IRCMessage msg(clients[15], msgStr);
+  requestHandler.handleCommand(msg);
+
+  // エラーメッセージ
+  EXPECT_EQ(clients[15]->getSendingMsg(), expected + "\r\n");
+  // 何も送信されない
+  EXPECT_EQ(clients[11]->getSendingMsg(), "");
+  EXPECT_EQ(clients[12]->getSendingMsg(), "");
+}
+
+// 引数エラー //////////////////////////////////////////////////////////
+
+// 引数なし
+TEST(CommandKick, no_arg) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "KICK";
+  std::string expected =
+      ":irc.example.net 461 nick1 KICK :Not enough parameters";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  // エラーメッセージ
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected + "\r\n");
+  // 何も送信されない
+  EXPECT_EQ(clients[11]->getSendingMsg(), "");
+  EXPECT_EQ(clients[12]->getSendingMsg(), "");
+}
+
+// 引数不足
+TEST(CommandKick, arg1) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "KICK #ch3";
+  std::string expected =
+      ":irc.example.net 461 nick1 KICK :Not enough parameters";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  // エラーメッセージ
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected + "\r\n");
+  // 何も送信されない
+  EXPECT_EQ(clients[11]->getSendingMsg(), "");
+  EXPECT_EQ(clients[12]->getSendingMsg(), "");
+}
+
+// 引数過剰
+TEST(CommandKick, arg4) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "KICK #ch3 nick2 bye bye";
+  std::string expected =
+      ":irc.example.net 461 nick1 KICK :Not enough parameters";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  // エラーメッセージ
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected + "\r\n");
+  // 何も送信されない
+  EXPECT_EQ(clients[11]->getSendingMsg(), "");
+  EXPECT_EQ(clients[12]->getSendingMsg(), "");
+}
+
+// チャンネルエラー //////////////////////////////////////////////////////////
+
+// チャンネルが存在しない
+TEST(CommandKick, not_exit_ch) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "KICK #chx nick2 :bye bye";
+  std::string expected = ":irc.example.net 403 nick1 #chx :No such channel";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  // エラーメッセージ
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected + "\r\n");
+  // 何も送信されない
+  EXPECT_EQ(clients[11]->getSendingMsg(), "");
+  EXPECT_EQ(clients[12]->getSendingMsg(), "");
+}
+
+// チャンネルに所属していない
+TEST(CommandKick, I_am_not_member) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "KICK #ch4 nick2 :bye bye";
+  std::string expected =
+      ":irc.example.net 442 nick1 #ch4 :You're not on that channel";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  // エラーメッセージ
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected + "\r\n");
+  // 何も送信されない
+  EXPECT_EQ(clients[11]->getSendingMsg(), "");
+  EXPECT_EQ(clients[12]->getSendingMsg(), "");
+}
+
+// 　権限がない（チャンネルのオペレーターではない）
+TEST(CommandKick, no_operator) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "KICK #ch3 nick2 :bye bye";
+  std::string expected =
+      ":irc.example.net 482 nick2 #ch3 :You're not channel operator";
+
+  IRCMessage msg(clients[11], msgStr);
+  requestHandler.handleCommand(msg);
+
+  // エラーメッセージ
+  EXPECT_EQ(clients[11]->getSendingMsg(), expected + "\r\n");
+  // 何も送信されない
+  EXPECT_EQ(clients[10]->getSendingMsg(), "");
+  EXPECT_EQ(clients[12]->getSendingMsg(), "");
+}
+
+// クライアントエラー //////////////////////////////////////////////////////////
+
+// ニックネームが存在しない
+TEST(CommandKick, not_exit_nick) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "KICK #ch3 xxx :bye bye";
+  std::string expected = ":irc.example.net 401 nick1 xxx :No such nick/channel";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  // エラーメッセージ
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected + "\r\n");
+  // 何も送信されない
+  EXPECT_EQ(clients[11]->getSendingMsg(), "");
+  EXPECT_EQ(clients[12]->getSendingMsg(), "");
+}
+
+// 対象者がチャンネルに参加していない
+TEST(CommandKick, nick_is_not_member) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "KICK #ch3 nick4 :bye bye";
+  std::string expected =
+      ":irc.example.net 441 nick1 nick4 #ch3 :They aren't on that channel";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  // エラーメッセージ
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected + "\r\n");
+  // 何も送信されない
+  EXPECT_EQ(clients[11]->getSendingMsg(), "");
+  EXPECT_EQ(clients[12]->getSendingMsg(), "");
+}


### PR DESCRIPTION
```Channel::menber_```と```Client::joinedChannels_```の整合性を取るために、
```Channel::addMember, removeMember```を呼ぶと、
内部で```Client::addJoinedChannel, removeJoinedChannel```を呼ぶようにしました。


クライアントが切断されたら、Channelのメンバーから削除など、
他にも整合性をとるために、色々必要なのですが、
おいおいやっていきます。