### PR TITLE
Add command PART and NULL and make not use BROADCAST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ SRCS := src/main.cpp src/IRCServer.cpp src/Client.cpp src/Channel.cpp\
 		src/commands/CommandUser.cpp src/commands/CommandPing.cpp \
 		src/commands/CommandJoin.cpp src/commands/CommandTopic.cpp \
 		src/commands/CommandMode.cpp src/commands/CommandInvite.cpp \
-		src/commands/CommandPrivMsg.cpp \
+		src/commands/CommandPart.cpp src/commands/CommandPrivMsg.cpp \
 		src/commands/CommandKick.cpp \
-		src/commands/CommandBroadCast.cpp
+		src/commands/CommandNull.cpp src/commands/CommandBroadCast.cpp
 OBJS = $(patsubst $(SRCS_ROOT_DIR)/%.cpp,$(OBJS_ROOT_DIR)/%.o,$(SRCS))
 
 #-----------------------------------------------

--- a/include/commands/ACommand.hpp
+++ b/include/commands/ACommand.hpp
@@ -30,6 +30,7 @@ class ACommand {
   // validation
   bool checkIsRegistered(IRCMessage& msg);
   bool checkParamNum(IRCMessage& msg, size_t min_params);
+  bool checkParamNum(IRCMessage& msg, size_t min, size_t max);
 
  public:
   // Orthodox Canonical Form

--- a/include/commands/CommandNull.hpp
+++ b/include/commands/CommandNull.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#ifndef __COMMAND_NULL_HPP__
+#define __COMMAND_NULL_HPP__
+
+#include "ACommand.hpp"
+
+class CommandNull : public ACommand {
+ public:
+  // Orthodox Canonical Form
+  CommandNull(IRCServer* server);
+  ~CommandNull();
+
+  // Member functions
+  void execute(IRCMessage& msg);
+
+ private:
+  CommandNull();
+  CommandNull(const CommandNull& other);
+  CommandNull& operator=(const CommandNull& other);
+};
+
+#endif  // __COMMAND_NULL_HPP__

--- a/include/commands/CommandPart.hpp
+++ b/include/commands/CommandPart.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#ifndef __COMMAND_PART_HPP__
+#define __COMMAND_PART_HPP__
+
+#include "ACommand.hpp"
+
+/**
+ * @brief IRC command "PART" handler.
+ * @note
+    Command: PART
+    Parameters: <channel>{,<channel>}
+    The PART message causes the client sending the message to be removed
+    from the list of active users for all given channels listed in the
+    parameter string.
+
+    Numeric Replies:
+            ERR_NEEDMOREPARAMS              ERR_NOSUCHCHANNEL
+            ERR_NOTONCHANNEL
+ * @cite https://www.rfc-editor.org/rfc/rfc1459.html#section-4.2.2
+ */
+
+class CommandPart : public ACommand {
+ public:
+  // Orthodox Canonical Form
+  CommandPart(IRCServer* server);
+  ~CommandPart();
+
+  // Member functions
+  void execute(IRCMessage& msg);
+
+ private:
+  CommandPart();
+  CommandPart(const CommandPart& other);
+  CommandPart& operator=(const CommandPart& other);
+
+  bool validatePart(IRCMessage& msg);
+  bool validChannel(IRCMessage& msg, const std::string& channelName);
+};
+
+#endif  // __COMMAND_PART_HPP__

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -127,6 +127,7 @@ bool Channel::addInvited(Client* client) {
 bool Channel::removeMember(Client* client) {
   if (member_.find(client) == member_.end()) return false;
   member_.erase(client);
+  chanop_.erase(client);
   client->removeJoinedChannel(name_);
   return true;
 }

--- a/src/IRCParser.cpp
+++ b/src/IRCParser.cpp
@@ -71,6 +71,9 @@ bool IRCParser::validCommand(const std::string& command) {
   if (command.find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZ") ==
       std::string::npos)
     return true;
+  if (command.find_first_not_of("abcdefghijklmnopqrstuvwxyz") ==
+      std::string::npos)
+    return true;
   if (command.find_first_not_of("0123456789") == std::string::npos &&
       command.size() == 3)
     return true;

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -167,8 +167,7 @@ bool IRCServer::addClient(Client* client) {
 }
 
 bool IRCServer::addChannel(const std::string& name, Client* client) {
-  if (channels_.find(name) != channels_.end())
-    return false;
+  if (channels_.find(name) != channels_.end()) return false;
   Channel* channel = new Channel(name, client);
   channels_[name] = channel;
   return true;
@@ -187,15 +186,15 @@ bool IRCServer::ifChannleExists(const std::string& name) const {
 //   return false;
 // }
 
-// bool IRCServer::removeChannel(const std::string& name) {
-//   std::map<std::string, Channel*>::iterator it = channels_.find(name);
-//   if (it != channels_.end()) {
-//     delete it->second;
-//     channels_.erase(it);
-//     return true;
-//   }
-//   return false;
-// }
+bool IRCServer::removeChannel(const std::string& name) {
+  std::map<std::string, Channel*>::iterator it = channels_.find(name);
+  if (it != channels_.end()) {
+    delete it->second;
+    channels_.erase(it);
+    return true;
+  }
+  return false;
+}
 
 void IRCServer::addSendQueue(Client* client) {
   send_queue_.insert(client);

--- a/src/RequestHandler.cpp
+++ b/src/RequestHandler.cpp
@@ -7,6 +7,8 @@
 #include "CommandKick.hpp"
 #include "CommandMode.hpp"
 #include "CommandNick.hpp"
+#include "CommandNull.hpp"
+#include "CommandPart.hpp"
 #include "CommandPass.hpp"
 #include "CommandPing.hpp"
 #include "CommandPrivMsg.hpp"
@@ -24,14 +26,14 @@ RequestHandler::RequestHandler(IRCServer* server) : server_(server) {
   commands_["USER"] = new CommandUser(server_);
   commands_["JOIN"] = new CommandJoin(server_);
   commands_["INVITE"] = new CommandInvite(server_);
-  // commands_["PART"] = new CommandPart(server_);
   commands_["TOPIC"] = new CommandTopic(server_);
   commands_["MODE"] = new CommandMode(server_);
   commands_["PRIVMSG"] = new CommandPrivMsg(server_);
+  commands_["PART"] = new CommandPart(server_);
   commands_["KICK"] = new CommandKick(server_);
-  // commands_["PART"] = new CommandPart(server_);
   commands_["PING"] = new CommandPing(server_);
   commands_["BROADCAST"] = new CommandBroadCast(server_);
+  commands_["NULL"] = new CommandNull(server_);
 }
 
 RequestHandler::~RequestHandler() {
@@ -47,9 +49,7 @@ RequestHandler::RequestHandler(const RequestHandler& other) {
 }
 
 RequestHandler& RequestHandler::operator=(const RequestHandler& other) {
-  if (this == &other) {
-    return *this;
-  }
+  if (this == &other) return *this;
   server_ = other.server_;
   commands_ = other.commands_;
   return *this;
@@ -77,12 +77,9 @@ ACommand* RequestHandler::getCommand(const std::string& commandName) {
 void RequestHandler::execCommand(IRCMessage& msg) {
   std::string commandName = msg.getCommand();
   ACommand* command = getCommand(commandName);
-  if (command) {
+  if (command)
     command->execute(msg);
-  } else {
-    commands_["BROADCAST"]->execute(msg);
-    // TODO ngircdのコマンドが見つからない場合のエラーメッセージ
-    // hoge
-    // 　:irc.example.net 421 nick1 hoge :Unknown command
-  }
+  else
+    commands_["NULL"]->execute(msg);
+  // commands_["BROADCAST"]->execute(msg);
 }

--- a/src/commands/ACommand.cpp
+++ b/src/commands/ACommand.cpp
@@ -56,6 +56,16 @@ bool ACommand::checkParamNum(IRCMessage& msg, size_t min_params) {
   return false;
 }
 
+bool ACommand::checkParamNum(IRCMessage& msg, size_t min, size_t max) {
+  Client* from = msg.getFrom();
+  size_t params_size = msg.getParams().size();
+  if (min <= params_size && params_size <= max) return true;
+  IRCMessage reply(from, from);
+  reply.setResCode(ERR_NEEDMOREPARAMS);
+  pushResponse(reply);
+  return false;
+}
+
 // Response handling
 void ACommand::pushResponse(IRCMessage& reply_msg) {
   std::ostringstream oss;
@@ -172,13 +182,10 @@ std::string ACommand::generateResponseMsg(IRCMessage& reply_msg) {
     case ERR_NOTEXTTOSEND:  // 412
       // ":No text to send"
       return ":No text to send";
-    // case ERR_UNKNOWNCOMMAND:  // 421
-    //   // <command> :Unknown command
-    //   if (reply_msg.getCommand().empty()) {
-    //     throw std::invalid_argument("ERR_TOOMANYCHANNELS");
-    //   }
-    //   oss << reply_msg.getCommand() << " :Unknown command";
-    //   return oss.str();
+    case ERR_UNKNOWNCOMMAND:  // 421
+      // <command> :Unknown command
+      oss << reply_msg.getParam(0) << " :Unknown command";
+      return oss.str();
     case ERR_NONICKNAMEGIVEN:  // 431
       // :No nickname given
       return ":No nickname given";

--- a/src/commands/CommandNull.cpp
+++ b/src/commands/CommandNull.cpp
@@ -1,0 +1,14 @@
+#include "CommandNull.hpp"
+
+CommandNull::CommandNull(IRCServer* server) : ACommand(server, "NULL") {}
+
+CommandNull::~CommandNull() {}
+
+void CommandNull::execute(IRCMessage& msg) {
+  Client* from = msg.getFrom();
+  if (!checkIsRegistered(msg)) return;
+  IRCMessage reply(from, from);
+  reply.setResCode(ERR_UNKNOWNCOMMAND);
+  reply.addParam(msg.getCommand());
+  pushResponse(reply);
+}

--- a/src/commands/CommandNull.cpp
+++ b/src/commands/CommandNull.cpp
@@ -6,7 +6,7 @@ CommandNull::~CommandNull() {}
 
 void CommandNull::execute(IRCMessage& msg) {
   Client* from = msg.getFrom();
-  if (!checkIsRegistered(msg)) return;
+  if (!from->getIsRegistered()) return;
   IRCMessage reply(from, from);
   reply.setResCode(ERR_UNKNOWNCOMMAND);
   reply.addParam(msg.getCommand());

--- a/src/commands/CommandPart.cpp
+++ b/src/commands/CommandPart.cpp
@@ -1,0 +1,68 @@
+#include "CommandPart.hpp"
+
+#include "Utils.hpp"
+
+CommandPart::CommandPart(IRCServer* server) : ACommand(server, "PART") {}
+
+CommandPart::~CommandPart() {}
+
+bool CommandPart::validatePart(IRCMessage& msg) {
+  if (!checkIsRegistered(msg)) return false;
+  if (!checkParamNum(msg, 1, 1)) return false;
+  return true;
+}
+
+void CommandPart::execute(IRCMessage& msg) {
+  if (!validatePart(msg)) return;
+  std::string channelsParam;
+  std::vector<std::string> channels = Utils::split(msg.getParam(0), ",");
+  Client* from = msg.getFrom();
+  for (size_t i = 0; i < channels.size(); ++i) {
+    const std::string& channelName = channels[i];
+    Channel* channel = server_->getChannel(channelName);
+    if (!validChannel(msg, channelName)) continue;
+    // チャンネルから脱退
+    channel->removeMember(from);
+    IRCMessage replyFrom(from, from);
+    replyFrom.addParam(channelName);
+    replyFrom.setCommand("PART");
+    pushResponse(replyFrom);
+    // チャンネルに誰もいなくなった場合、チャンネルを削除
+    if (channel->getMember().empty()) {
+      server_->removeChannel(channelName);
+    } else {
+      std::set<Client*> members = channel->getMember();
+      for (std::set<Client*>::iterator it = members.begin();
+           it != members.end(); ++it) {
+        IRCMessage reply(from, *it);
+        reply.setCommand("PART");
+        reply.addParam(channelName);
+        reply.setBody(msg.getBody());
+        pushResponse(reply);
+      }
+    }
+  }
+}
+
+bool CommandPart::validChannel(IRCMessage& msg,
+                               const std::string& channelName) {
+  Client* from = msg.getFrom();
+  Channel* channel = server_->getChannel(channelName);
+  if (!channel) {
+    // チャンネルが存在しない場合
+    IRCMessage reply(from, from);
+    reply.setResCode(ERR_NOSUCHCHANNEL);
+    reply.addParam(channelName);
+    pushResponse(reply);
+    return false;
+  }
+  if (!channel->isMember(from)) {
+    // チャンネルに参加していない場合
+    IRCMessage reply(from, from);
+    reply.setResCode(ERR_NOTONCHANNEL);
+    reply.addParam(channelName);
+    pushResponse(reply);
+    return false;
+  }
+  return true;
+}

--- a/test/unit/src/Commands/TestCommandPart.cpp
+++ b/test/unit/src/Commands/TestCommandPart.cpp
@@ -1,0 +1,167 @@
+#include <gtest/gtest.h>
+
+#include "IRCServer.hpp"
+#include "RequestHandler.hpp"
+#include "TestDataGenerator.hpp"
+
+// 正常（１チャンネルから退出）
+TEST(CommandPart, normalPart) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string channelName = "#ch2";
+  std::string msgStr = "PART " + channelName;
+  std::string expected_reply = ":nick1!~user1@localhost PART #ch2";
+
+  IRCMessage msg01(clients[10], msgStr);
+  requestHandler.handleCommand(msg01);
+
+  EXPECT_FALSE(server.getChannel(channelName)->isMember(clients[10]));
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected_reply + "\r\n");
+}
+
+// 正常 (複数チャンネルから退出)
+TEST(CommandPart, normalPartMultipleChannels) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string channelNames = "#ch1,#ch2";
+
+  std::string msgStr = "PART " + channelNames;
+  std::string expected_reply1 =
+      ":nick1!~user1@localhost PART #ch1"
+      "\r\n"
+      ":nick1!~user1@localhost PART #ch2";
+
+  std::string expected_reply2 = ":nick1!~user1@localhost PART #ch2";
+
+  IRCMessage msg01(clients[10], msgStr);
+  requestHandler.handleCommand(msg01);
+
+  EXPECT_FALSE(server.getChannel("#ch1")->isMember(clients[10]));
+  EXPECT_FALSE(server.getChannel("#ch2")->isMember(clients[10]));
+
+  std::string sendingMsg = clients[10]->getSendingMsg();
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected_reply1 + "\r\n");
+  EXPECT_EQ(clients[11]->getSendingMsg(), expected_reply2 + "\r\n");
+}
+
+// // 異常 (パラメーターがない場合)
+TEST(CommandPart, noParameters) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "PART";
+  std::string expected_reply =
+      ":irc.example.net 461 nick1 PART :Not enough parameters";
+
+  IRCMessage msg01(clients[10], msgStr);
+  requestHandler.handleCommand(msg01);
+
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected_reply + "\r\n");
+}
+
+// 異常（パラメーターが多すぎる場合）
+TEST(CommandPart, tooManyParameters) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string channelName = "#ch1";
+  std::string msgStr = "PART #ch1 extra param";
+  std::string expected_reply =
+      ":irc.example.net 461 nick1 PART :Not enough parameters";
+
+  IRCMessage msg01(clients[10], msgStr);
+  requestHandler.handleCommand(msg01);
+
+  EXPECT_TRUE(server.getChannel(channelName)->isMember(clients[10]));
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected_reply + "\r\n");
+}
+
+// 異常 (チャンネルが存在しない場合)
+TEST(CommandPart, channelNotExists) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "PART #noexist";
+  std::string expected_reply =
+      ":irc.example.net 403 nick1 #noexist :No such channel";
+
+  IRCMessage msg01(clients[10], msgStr);
+  requestHandler.handleCommand(msg01);
+
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected_reply + "\r\n");
+}
+
+// // 正常 (チャンネルオペレーターが退出する場合)
+TEST(CommandPart, operatorPart) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string channelName = "#ch1";
+  std::string msgStr = "PART " + channelName;
+  std::string expected_reply = ":nick1!~user1@localhost PART #ch1";
+
+  IRCMessage msg01(clients[10], msgStr);
+  requestHandler.handleCommand(msg01);
+
+  EXPECT_FALSE(server.getChannel(channelName)->isMember(clients[10]));
+  EXPECT_FALSE(server.getChannel(channelName)->isChanop(clients[10]));
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected_reply + "\r\n");
+}
+
+// 異常 (チャンネルに参加していない場合)
+TEST(CommandPart, notOnChannel) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string channelName = "#ch4";
+  std::string msgStr = "PART " + channelName;
+  std::string expected_reply =
+      ":irc.example.net 442 nick1 #ch4 :You're not on that channel";
+
+  IRCMessage msg01(clients[10], msgStr);
+  requestHandler.handleCommand(msg01);
+
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected_reply + "\r\n");
+}
+
+// 正常 (最後のメンバーが退出してチャンネルが削除される場合)
+TEST(CommandPart, lastMemberPartChannelDestroyed) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string channelName = "#ch1";
+
+  Channel *channel = server.getChannel(channelName);
+
+  IRCMessage msg01(clients[13], "PART " + channelName);
+  requestHandler.handleCommand(msg01);
+  clients[10]->consumeSendingMsg(
+      100000);  // クライアントの送信メッセージをクリア
+
+  std::string msgStr = "PART " + channelName;
+  std::string expected_reply = ":nick1!~user1@localhost PART #ch1";
+
+  IRCMessage msg02(clients[10], msgStr);
+  requestHandler.handleCommand(msg02);
+
+  EXPECT_EQ(server.getChannel(channelName), nullptr);
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected_reply + "\r\n");
+}

--- a/test/unit/src/Commands/testCommandNull.cpp
+++ b/test/unit/src/Commands/testCommandNull.cpp
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+
+#include "IRCServer.hpp"
+#include "RequestHandler.hpp"
+#include "TestDataGenerator.hpp"
+
+// 正常（大文字）
+TEST(CommandPart, capitalNull) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "ABCDE";
+  std::string expected_reply = ":irc.example.net 421 nick1 ABCDE :Unknown command";
+
+  IRCMessage msg01(clients[10], msgStr);
+  requestHandler.handleCommand(msg01);
+
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected_reply + "\r\n");
+}
+
+// 正常（小文字）
+TEST(CommandPart, smallNull) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "abcde";
+  std::string expected_reply = ":irc.example.net 421 nick1 abcde :Unknown command";
+
+  IRCMessage msg01(clients[10], msgStr);
+  requestHandler.handleCommand(msg01);
+
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected_reply + "\r\n");
+}
+
+// 正常（数字）
+TEST(CommandPart, numNull) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "999";
+  std::string expected_reply = ":irc.example.net 421 nick1 999 :Unknown command";
+
+  IRCMessage msg01(clients[10], msgStr);
+  requestHandler.handleCommand(msg01);
+
+  EXPECT_EQ(clients[10]->getSendingMsg(), expected_reply + "\r\n");
+}
+


### PR DESCRIPTION
## PARTとNULLを追加
- PART（退出）
    - subjectには入っていませんが、自分でチャンネルから出られるようにはした方がいいと思い、追加しました。
- NULL（何もコマンドが該当しない場合）
    - 同時にBROADCASTをコメントアウトしました。（副次的にBROADCASTのtestがエラーを吐くようになっています）

一旦これで全コマンドかなと思いますが、どうでしょう？

## TODO
特にコマンドにバリデーション(`IRCParser::validCommand()`)いらないかも？ ->追って