### PR TITLE
本番環境用のビルドが通るように修正しました #49

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,16 @@ CXX = c++
 
 INCL_FLAGS = $(foreach d, $(INCL_DIR), -I$d)
 W3_FLAGS = -Wall -Wextra -Werror
-OTHER_FLAGS = -O0 -g -std=c++98 -pedantic-errors -DDEBUG
+
+OTHER_FLAGS := -O2 -std=c++98 -pedantic-errors
+ifdef DEBUG
+	OTHER_FLAGS := -O0 -g -std=c++98 -pedantic-errors -DDEBUG
+endif
+
+
+
 CXXFLAGS = $(INCL_FLAGS) $(W3_FLAGS) $(OTHER_FLAGS)
 
-ifdef PROD_FLG
-		CXXFLAGS := -I./include -Wall -Wextra -Werror -O2 -std=c++98 -pedantic-errors
-endif
 
 #===============================================
 # Colors

--- a/src/IRCSignal.cpp
+++ b/src/IRCSignal.cpp
@@ -6,9 +6,11 @@
 
 volatile sig_atomic_t g_signal = 0;
 
+#ifdef DEBUG
 static void debug_handler(int sig) {
   DEBUG_MSG("signal: " << sig);
 }
+#endif
 
 static void shutdown_handler(int sig) {
   DEBUG_MSG("signal: " << sig);


### PR DESCRIPTION
#49 

デフォルトを本番環境にしたので、
これまで通りデバッグログを出したい場合は
```
DEBUG=1 make re
```
して下さい。
面倒くさいかな？デフォルトDEBUGの方がいい？