### PR TITLE
USERコマンドのテストを追加しました

### DIFF
--- a/include/commands/ACommand.hpp
+++ b/include/commands/ACommand.hpp
@@ -29,8 +29,8 @@ class ACommand {
 
   // validation
   bool checkIsRegistered(IRCMessage& msg);
-  bool checkParamNum(IRCMessage& msg, size_t min_params);
-  bool checkParamNum(IRCMessage& msg, size_t min, size_t max);
+  bool checkParamNum(const IRCMessage& msg, size_t min_params);
+  bool checkParamNum(const IRCMessage& msg, size_t min, size_t max);
 
  public:
   // Orthodox Canonical Form

--- a/include/commands/CommandUser.hpp
+++ b/include/commands/CommandUser.hpp
@@ -4,6 +4,58 @@
 
 #include "ACommand.hpp"
 
+/**
+ * @brief IRC command "USER" handler.
+ * @details This class handles the "USER" command in IRC.
+ *
+ * @note
+      Command: USER
+   Parameters: <username> <hostname> <servername> <realname>
+
+   The USER message is used at the beginning of connection to specify
+   the username, hostname, servername and realname of s new user.  It is
+   also used in communication between servers to indicate new user
+   arriving on IRC, since only after both USER and NICK have been
+   received from a client does a user become registered.
+
+   Between servers USER must to be prefixed with client's NICKname.
+   Note that hostname and servername are normally ignored by the IRC
+   server when the USER command comes from a directly connected client
+   (for security reasons), but they are used in server to server
+   communication.  This means that a NICK must always be sent to a
+   remote server when a new user is being introduced to the rest of the
+   network before the accompanying USER is sent.
+
+   It must be noted that realname parameter must be the last parameter,
+   because it may contain space characters and must be prefixed with a
+   colon (':') to make sure this is recognised as such.
+
+   Since it is easy for a client to lie about its username by relying
+   solely on the USER message, the use of an "Identity Server" is
+   recommended.  If the host which a user connects from has such a
+   server enabled the username is set to that as in the reply from the
+   "Identity Server".
+
+   Numeric Replies:
+
+           ERR_NEEDMOREPARAMS              ERR_ALREADYREGISTRED
+
+   Examples:
+
+
+   USER guest tolmoon tolsun :Ronnie Reagan
+                                   ; User registering themselves with a
+                                   username of "guest" and real name
+                                   "Ronnie Reagan".
+
+
+   :testnick USER guest tolmoon tolsun :Ronnie Reagan
+                                   ; message between servers with the
+                                   nickname for which the USER command
+                                   belongs to
+ * @cite https://www.rfc-editor.org/rfc/rfc1459#section-4.1.3
+*/
+
 class CommandUser : public ACommand {
  public:
   // Orthodox Canonical Form
@@ -17,6 +69,8 @@ class CommandUser : public ACommand {
   CommandUser();
   CommandUser(const CommandUser& other);
   CommandUser& operator=(const CommandUser& other);
+
+  bool validateUser(const IRCMessage& msg);
 };
 
 #endif  // __COMMAND_USER_HPP__

--- a/src/commands/ACommand.cpp
+++ b/src/commands/ACommand.cpp
@@ -46,7 +46,7 @@ bool ACommand::checkIsRegistered(IRCMessage& msg) {
   return false;
 }
 
-bool ACommand::checkParamNum(IRCMessage& msg, size_t min_params) {
+bool ACommand::checkParamNum(const IRCMessage& msg, size_t min_params) {
   Client* from = msg.getFrom();
   size_t params_size = msg.getParams().size();
   if (min_params <= params_size) return true;
@@ -56,7 +56,7 @@ bool ACommand::checkParamNum(IRCMessage& msg, size_t min_params) {
   return false;
 }
 
-bool ACommand::checkParamNum(IRCMessage& msg, size_t min, size_t max) {
+bool ACommand::checkParamNum(const IRCMessage& msg, size_t min, size_t max) {
   Client* from = msg.getFrom();
   size_t params_size = msg.getParams().size();
   if (min <= params_size && params_size <= max) return true;

--- a/src/commands/CommandUser.cpp
+++ b/src/commands/CommandUser.cpp
@@ -4,22 +4,37 @@ CommandUser::CommandUser(IRCServer* server) : ACommand(server, "USER") {}
 
 CommandUser::~CommandUser() {}
 
-void CommandUser::execute(IRCMessage& msg) {
-  Client* from = msg.getFrom();
-  IRCMessage reply(from, from);
+bool CommandUser::validateUser(const IRCMessage& msg) {
+  if (!checkParamNum(msg, 4, 4)) {
+    return false;
+  }
+
+  IRCMessage reply(msg.getFrom(), msg.getFrom());
   reply.setParams(msg.getParams());
 
-  if (msg.getParam(0).empty() || msg.getParam(3).empty()) {
-    reply.setResCode(ERR_NEEDMOREPARAMS);
-    pushResponse(reply);
-    return;
-  }
-  if (from->getIsRegistered()) {
+  if (msg.getFrom()->getIsRegistered()) {
     reply.setResCode(ERR_ALREADYREGISTRED);
     pushResponse(reply);
+    return false;
+  }
+
+  if (!msg.getFrom()->getUserName().empty() ||
+      !msg.getFrom()->getRealName().empty()) {
+    reply.setResCode(ERR_NOTREGISTERED);
+    pushResponse(reply);
+    return false;
+  }
+
+  return true;
+}
+
+void CommandUser::execute(IRCMessage& msg) {
+  Client* from = msg.getFrom();
+
+  if (!validateUser(msg)) {
     return;
   }
-  // TODO: Valid入れる？
+
   from->setUserName(msg.getParam(0));
   from->setRealName(msg.getParam(3));
   registrate(msg);

--- a/test/unit/src/Commands/TestCommandUser.cpp
+++ b/test/unit/src/Commands/TestCommandUser.cpp
@@ -1,0 +1,165 @@
+#include <gtest/gtest.h>
+
+#include "TestDataGenerator.hpp"
+
+// 正常
+TEST(CommandUser, nomal) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+
+  clients[10] = new Client(10);
+  server.addClient(clients[10]);
+
+  std::string msgStr =
+      "user username hostname servername :real name with spaces";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  EXPECT_EQ(server.getClients().at(10)->getUserName(), "username");
+  EXPECT_EQ(server.getClients().at(10)->getRealName(), "real name with spaces");
+  EXPECT_EQ(clients[10]->getSendingMsg(), "");
+}
+
+// 引数なし
+TEST(CommandUser, no_arg) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+
+  clients[10] = new Client(10);
+  server.addClient(clients[10]);
+
+  std::string msgStr = "USER";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  EXPECT_EQ(server.getClients().at(10)->getUserName(), "");
+  EXPECT_EQ(server.getClients().at(10)->getRealName(), "");
+  EXPECT_EQ(clients[10]->getSendingMsg(),
+            ":irc.example.net 461 * USER :Not enough parameters\r\n");
+}
+
+// 引数1
+TEST(CommandUser, arg1) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+
+  clients[10] = new Client(10);
+  server.addClient(clients[10]);
+
+  std::string msgStr = "USER username";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  EXPECT_EQ(server.getClients().at(10)->getUserName(), "");
+  EXPECT_EQ(server.getClients().at(10)->getRealName(), "");
+  EXPECT_EQ(clients[10]->getSendingMsg(),
+            ":irc.example.net 461 * USER :Not enough parameters\r\n");
+}
+
+// 引数2
+TEST(CommandUser, arg2) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+
+  clients[10] = new Client(10);
+  server.addClient(clients[10]);
+
+  std::string msgStr = "USER username hostname";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  EXPECT_EQ(server.getClients().at(10)->getUserName(), "");
+  EXPECT_EQ(server.getClients().at(10)->getRealName(), "");
+  EXPECT_EQ(clients[10]->getSendingMsg(),
+            ":irc.example.net 461 * USER :Not enough parameters\r\n");
+}
+
+// 引数3
+TEST(CommandUser, arg3) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+
+  clients[10] = new Client(10);
+  server.addClient(clients[10]);
+
+  std::string msgStr = "USER username hostname servername";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  EXPECT_EQ(server.getClients().at(10)->getUserName(), "");
+  EXPECT_EQ(server.getClients().at(10)->getRealName(), "");
+  EXPECT_EQ(clients[10]->getSendingMsg(),
+            ":irc.example.net 461 * USER :Not enough parameters\r\n");
+}
+
+// 引数5
+TEST(CommandUser, arg5) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+
+  clients[10] = new Client(10);
+  server.addClient(clients[10]);
+
+  std::string msgStr = "USER username hostname servername realname extra";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  EXPECT_EQ(server.getClients().at(10)->getUserName(), "");
+  EXPECT_EQ(server.getClients().at(10)->getRealName(), "");
+  EXPECT_EQ(clients[10]->getSendingMsg(),
+            ":irc.example.net 461 * USER :Not enough parameters\r\n");
+}
+
+// 既にログイン済み
+TEST(CommandUser, registered) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  std::string msgStr = "USER username hostname servername realname ";
+
+  IRCMessage msg(clients[10], msgStr);
+  requestHandler.handleCommand(msg);
+
+  EXPECT_EQ(server.getClients().at(10)->getUserName(), "user1");
+  EXPECT_EQ(server.getClients().at(10)->getRealName(), "Real Name 1");
+  EXPECT_EQ(clients[10]->getSendingMsg(),
+            ":irc.example.net 462 nick1 :You may not reregister\r\n");
+}
+
+// ログイン前2回実行(ngircdではログイン前に2回実行するとエラーになる。ここまで寄せる必要ない気もするけど)
+TEST(CommandUser, two_times) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client *> clients;
+  RequestHandler requestHandler(&server);
+
+  clients[10] = new Client(10);
+  server.addClient(clients[10]);
+
+  std::string msgStr1 = "USER username1 hostname servername realname1";
+  std::string msgStr2 = "USER username2 hostname servername realname2";
+
+  IRCMessage msg1(clients[10], msgStr1);
+  requestHandler.handleCommand(msg1);
+  IRCMessage msg2(clients[10], msgStr2);
+  requestHandler.handleCommand(msg2);
+
+  EXPECT_EQ(server.getClients().at(10)->getUserName(), "username1");
+  EXPECT_EQ(server.getClients().at(10)->getRealName(), "realname1");
+  EXPECT_EQ(clients[10]->getSendingMsg(),
+            ":irc.example.net 451 * :You have not registered\r\n");
+}


### PR DESCRIPTION
[USER] USERのテストコードがない #45
[USER] username realname のバリデーションがない #43

ngircdでは、username、realnameの文字数制限などはなさそうなので、何もチェックは追加していません。

ngircdでは、ログイン前に2回USERを呼ぶとエラーになって、切断されます。
そこまで寄せる必要があるのかよく分かりませんが、
とりあえずエラーは実装しました。
（切断までは実装していません）


