### PR TITLE
Add <name>suffix of RPL_NAMREPLY when JOIN command called

### DIFF
--- a/src/commands/ACommand.cpp
+++ b/src/commands/ACommand.cpp
@@ -136,7 +136,7 @@ std::string ACommand::generateResponseMsg(IRCMessage& reply_msg) {
       return oss.str();
     case RPL_NAMREPLY:  // 353
       // <channel> :[[@|+]<nick> [[@|+]<nick> [...]]]
-      oss << reply_msg.getParam(0) << " :" << reply_msg.getParam(1);
+      oss << "= " << reply_msg.getParam(0) << " :" << reply_msg.getParam(1);
       return oss.str();
     case RPL_ENDOFNAMES:  // 366
       // <channel> :End of /NAMES list

--- a/src/commands/CommandJoin.cpp
+++ b/src/commands/CommandJoin.cpp
@@ -31,15 +31,8 @@ void CommandJoin::execute(IRCMessage& msg) {
 
 bool CommandJoin::validJoin(IRCMessage& msg) {
   if (!checkIsRegistered(msg)) return false;
-  if (!checkParamNum(msg, 1)) return false;
-
+  if (!checkParamNum(msg, 1, 2)) return false;
   Client* from = msg.getFrom();
-  IRCMessage reply(from, from);
-  if (2 < msg.getParams().size()) {
-    reply.setResCode(ERR_NEEDMOREPARAMS);
-    pushResponse(reply);
-    return false;
-  }
   return true;
 }
 
@@ -123,7 +116,8 @@ void CommandJoin::addClientToNewChannel(IRCMessage& msg,
   sendResponceToFrom(msg, channelName);
 }
 
-void CommandJoin::sendResponseToChannel(IRCMessage& msg, std::string channelName) {
+void CommandJoin::sendResponseToChannel(IRCMessage& msg,
+                                        std::string channelName) {
   Channel* channel = server_->getChannel(channelName);
   Client* from = msg.getFrom();
   std::set<Client*> members = channel->getMember();
@@ -158,6 +152,10 @@ void CommandJoin::sendResponceToFrom(IRCMessage& msg, std::string channelName) {
   for (std::set<Client*>::iterator it = members.begin(); it != members.end();
        it++) {
     if (!nameList.empty()) nameList += " ";
+    if (channel->isChanop(*it))
+      nameList += "@";
+    else if (channel->isMember(*it))
+      nameList += "+";
     nameList += (*it)->getNickName();
   }
   nameReply.addParam(nameList);

--- a/test/unit/src/Commands/testCommandJoin.cpp
+++ b/test/unit/src/Commands/testCommandJoin.cpp
@@ -35,7 +35,7 @@ TEST(CommandJoin, normalJoin) {
   std::string expected_reply =
       ":nick1!~user1@localhost JOIN #channel"
       "\r\n"
-      ":irc.example.net 353 nick1 #channel :nick1"
+      ":irc.example.net 353 nick1 = #channel :@nick1"
       "\r\n"
       ":irc.example.net 366 nick1 #channel :End of /NAMES list";
   IRCMessage msg(clients[10], msgStr);
@@ -59,7 +59,7 @@ TEST(CommandJoin, withAndNewChannel) {
   std::string expected_reply =
       ":nick1!~user1@localhost JOIN &channel"
       "\r\n"
-      ":irc.example.net 353 nick1 &channel :nick1"
+      ":irc.example.net 353 nick1 = &channel :@nick1"
       "\r\n"
       ":irc.example.net 366 nick1 &channel :End of /NAMES list";
 
@@ -82,13 +82,13 @@ TEST(CommandJoin, withExistingChannel) {
   std::string expected_reply01 =
       ":nick1!~user1@localhost JOIN #channel"
       "\r\n"
-      ":irc.example.net 353 nick1 #channel :nick1"
+      ":irc.example.net 353 nick1 = #channel :@nick1"
       "\r\n"
       ":irc.example.net 366 nick1 #channel :End of /NAMES list";
   std::string expected_reply02 =
       ":nick2!~user2@localhost JOIN #channel"
       "\r\n"
-      ":irc.example.net 353 nick2 #channel :nick1 nick2"
+      ":irc.example.net 353 nick2 = #channel :@nick1 +nick2"
       "\r\n"
       ":irc.example.net 366 nick2 #channel :End of /NAMES list";
 
@@ -121,13 +121,13 @@ TEST(CommandJoin, joinMultipleChannels) {
   std::string expected_reply =
       ":nick1!~user1@localhost JOIN #channel1"
       "\r\n"
-      ":irc.example.net 353 nick1 #channel1 :nick1"
+      ":irc.example.net 353 nick1 = #channel1 :@nick1"
       "\r\n"
       ":irc.example.net 366 nick1 #channel1 :End of /NAMES list"
       "\r\n"
       ":nick1!~user1@localhost JOIN #channel2"
       "\r\n"
-      ":irc.example.net 353 nick1 #channel2 :nick1"
+      ":irc.example.net 353 nick1 = #channel2 :@nick1"
       "\r\n"
       ":irc.example.net 366 nick1 #channel2 :End of /NAMES list";
 
@@ -154,13 +154,13 @@ TEST(CommandJoin, joinMultipleChannelsWithKeys) {
   std::string expected_reply =
       ":nick1!~user1@localhost JOIN #channel1"
       "\r\n"
-      ":irc.example.net 353 nick1 #channel1 :nick1 nick2"
+      ":irc.example.net 353 nick1 = #channel1 :+nick1 @nick2"
       "\r\n"
       ":irc.example.net 366 nick1 #channel1 :End of /NAMES list"
       "\r\n"
       ":nick1!~user1@localhost JOIN #channel2"
       "\r\n"
-      ":irc.example.net 353 nick1 #channel2 :nick1 nick2"
+      ":irc.example.net 353 nick1 = #channel2 :+nick1 @nick2"
       "\r\n"
       ":irc.example.net 366 nick1 #channel2 :End of /NAMES list";
 
@@ -196,7 +196,7 @@ TEST(CommandJoin, rejoinChannel) {
   std::string expected_reply01 =
       ":nick1!~user1@localhost JOIN #channel"
       "\r\n"
-      ":irc.example.net 353 nick1 #channel :nick1"
+      ":irc.example.net 353 nick1 = #channel :@nick1"
       "\r\n"
       ":irc.example.net 366 nick1 #channel :End of /NAMES list";
 
@@ -285,7 +285,7 @@ TEST(CommandJoin, channelWithKey) {
   std::string expected_reply1 =
       ":nick1!~user1@localhost JOIN #ch1"
       "\r\n"
-      ":irc.example.net 353 nick1 #ch1 :nick1"
+      ":irc.example.net 353 nick1 = #ch1 :@nick1"
       "\r\n"
       ":irc.example.net 366 nick1 #ch1 :End of /NAMES list";
 
@@ -332,7 +332,7 @@ TEST(CommandJoin, inviteOnlyChannel_invited) {
   std::string expected_reply =
       ":nick1!~user1@localhost JOIN #channel"
       "\r\n"
-      ":irc.example.net 353 nick1 #channel :nick2 nick1"
+      ":irc.example.net 353 nick1 = #channel :@nick2 +nick1"
       "\r\n"
       ":irc.example.net 366 nick1 #channel :End of /NAMES list";
 
@@ -386,7 +386,7 @@ TEST(CommandJoin, inviteOnlyChannel_rejoin) {
   std::string expected_reply01 =
       ":nick1!~user1@localhost JOIN #channel"
       "\r\n"
-      ":irc.example.net 353 nick1 #channel :nick2 nick1"
+      ":irc.example.net 353 nick1 = #channel :@nick2 +nick1"
       "\r\n"
       ":irc.example.net 366 nick1 #channel :End of /NAMES list";
 
@@ -445,7 +445,7 @@ TEST(CommandJoin, joinChannelWithTopic) {
       "\r\n"
       ":irc.example.net 332 nick1 #channel :This is a topic"
       "\r\n"
-      ":irc.example.net 353 nick1 #channel :nick1 nick2"
+      ":irc.example.net 353 nick1 = #channel :@nick1 +nick2"
       "\r\n"
       ":irc.example.net 366 nick1 #channel :End of /NAMES list";
 


### PR DESCRIPTION
#57 の対応をしました。
現状のチャンネル作成ではChannelの`<type>`はPublicだけなので `=`のみ表示しています。

メンバーは
* `@`: チャンネルオペレーター（オペ）。
* `+`: 発言権があるユーザー。

の２種類の前提で修正しています。