### PR TITLE
使用されているポートをlistenした時にメモリリーク

### DIFF
--- a/src/IOWrapper.cpp
+++ b/src/IOWrapper.cpp
@@ -15,14 +15,14 @@ IOWrapper::IOWrapper() {
   epfd_ = epoll_create1(EPOLL_CLOEXEC);
   if (epfd_ == -1) {
     ERROR_MSG("epoll_create failed");
-    std::exit(EXIT_FAILURE);
+    throw std::runtime_error("epoll_create failed");
   }
 }
 
 IOWrapper::~IOWrapper() {
   if (close(epfd_) == -1) {
     ERROR_MSG("close epfd failed.");
-    std::exit(EXIT_FAILURE);
+    throw std::runtime_error("close epfd failed");
   }
 }
 

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -212,7 +212,7 @@ void IRCServer::startListen() {
   int ret = getaddrinfo(NULL, port_.c_str(), &hints, &res);
   if (ret != 0) {
     ERROR_MSG("getaddrinfo: " << gai_strerror(ret));
-    std::exit(EXIT_FAILURE);
+    throw std::runtime_error("getaddrinfo failed");
   }
   for (ai = res; ai != NULL; ai = ai->ai_next) {
     int sockfd =
@@ -259,7 +259,7 @@ void IRCServer::startListen() {
   freeaddrinfo(res);  // アドレス情報の解放
   if (listenSockets_.empty()) {
     ERROR_MSG("socket/bind/listen failed");
-    std::exit(EXIT_FAILURE);
+    throw std::runtime_error("socket/bind/listen failed");
   }
 }
 
@@ -411,7 +411,7 @@ void IRCServer::run() {
 
         if (close(evlist[j].data.fd) == -1) {
           ERROR_MSG("close failed");
-          std::exit(EXIT_FAILURE);
+          throw std::runtime_error("close failed");
         }
         listenSockets_.erase(evlist[j].data.fd);
       }


### PR DESCRIPTION
#67 
使用されているポートをlistenした時にexitが呼ばれ、
デストラクタが呼ばれないため、メモリリークが発生していた。
exitではなく、throwに変更し、デストラクタが呼ばれるように修正しました。