### PR TITLE
INVITEコマンド修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,12 @@ client: all
 	read NICK; \
 	irssi --connect=127.0.0.1 --port=6677 --nick=$$NICK --password=pass123
 
+.PHONY: clientng
+clientng: all
+	@printf "Please enter a nickname: "; \
+	read NICK; \
+	irssi --connect=127.0.0.1 --port=6667 --nick=$$NICK
+
 .PHONY: nc
 nc: all
 	nc -C -4 127.0.0.1 6677

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -43,12 +43,13 @@ class Channel {
   std::set<Client*> chanop_;
   std::set<Client*> invited_;
 
+  Channel();
+  Channel(const Channel& other);
+  Channel& operator=(const Channel& other);
+
  public:
   // Orthodox Cannonical Form
-  // Channel();
   ~Channel();
-  // Channel(const Channel& other);
-  // Channel& operator=(const Channel& other);
   Channel(const std::string& name, Client* client);
 
   // Getters

--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -38,6 +38,9 @@ class IRCServer {
 
   static const int kMaxBacklog = 100;
 
+  IRCServer(const IRCServer& other);
+  IRCServer& operator=(const IRCServer& other);
+
  public:
   static const int kMaxMsgSize = 510;  // IRCの仕様
 
@@ -45,8 +48,6 @@ class IRCServer {
   IRCServer();
   IRCServer(const char* port, const char* password);
   ~IRCServer();
-  // IRCServer(const IRCServer& other);
-  // IRCServer& operator=(const IRCServer& other);
 
   // Getters
   const std::map<int, Client*>& getClients() const;

--- a/include/commands/CommandMode.hpp
+++ b/include/commands/CommandMode.hpp
@@ -58,14 +58,14 @@
  */
 
 class CommandMode : public ACommand {
-  private:
+ private:
   CommandMode();
   CommandMode(const CommandMode& other);
   CommandMode& operator=(const CommandMode& other);
 
   // Member functions
   bool validateMode(IRCMessage& msg);
-   bool validClient(IRCMessage& msg, Client* client);
+  bool validClient(IRCMessage& msg, Client* client);
   bool plusI(Channel* channel, Client* from);
   bool minusI(Channel* channel, Client* from);
   bool plusT(Channel* channel, Client* from);
@@ -77,14 +77,13 @@ class CommandMode : public ACommand {
   bool plusL(Channel* channel, Client* from, std::string limit);
   bool minusL(Channel* channel, Client* from);
 
-  public:
-   // Orthodox Canonical Form
-   CommandMode(IRCServer* server);
-   ~CommandMode();
+ public:
+  // Orthodox Canonical Form
+  CommandMode(IRCServer* server);
+  ~CommandMode();
 
-   // Member functions
-   void execute(IRCMessage& msg);
-
+  // Member functions
+  void execute(IRCMessage& msg);
 };
 
 #endif  // __COMMAND_MODE_HPP__

--- a/src/commands/CommandInvite.cpp
+++ b/src/commands/CommandInvite.cpp
@@ -61,7 +61,7 @@ bool CommandInvite::validateInvite(IRCMessage& msg) {
     pushResponse(reply);
     return false;
   }
-  if (!channel->isChanop(from)) {
+  if (channel->getIsInviteOnly() && !channel->isChanop(from)) {
     reply.setResCode(ERR_CHANOPRIVSNEEDED);
     reply.addParam(channel->getName());
     pushResponse(reply);


### PR DESCRIPTION
[INVITE] mode iでない場合は一般ユーザーでもINVITEを送信できる #77

「mode iではない場合、だれでも招待可能」に修正しました。

## おまけ
- Orthodox Cannonical Formになっていないものを修正しました。
Orthodox Cannonical Formの対象となる関数が定義されていない場合、
コンパイラが勝手に作ってしまって、予期せぬ動きとなる可能性があるため、
使用しない場合はprivateに宣言しておき、使用されないようにしました。

- インデントがおかしいファイルを修正しました。

- irssiでngricdに接続したいことが多いので、makefileにターゲットを追加しました。
下記でirssiを使用して、ngircdに接続します。
```
make clientng
```