### PR TITLE
join 0を実装しました

### DIFF
--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -56,6 +56,7 @@ class IRCServer {
   const std::string& getPort() const;
   const std::string& getPassword() const;
   const std::string& getServerName() const;
+  RequestHandler& getRequestHandler();
 
   // Setters
   bool addClient(Client* client);

--- a/include/commands/CommandJoin.hpp
+++ b/include/commands/CommandJoin.hpp
@@ -53,7 +53,7 @@ class CommandJoin : public ACommand {
   // Member functions
   void execute(IRCMessage& msg);
 
-  private:
+ private:
   CommandJoin();
   CommandJoin(const CommandJoin& other);
   CommandJoin& operator=(const CommandJoin& other);
@@ -61,11 +61,14 @@ class CommandJoin : public ACommand {
   // Member functions
   bool validJoin(IRCMessage& msg);
   bool validChannnelName(std::string channelName);
-  void joinOneChannel(IRCMessage& msg, std::string channelName, std::string key);
-  void addClientToNewChannel(IRCMessage& msg, std::string channelName, std::string key);
+  void joinOneChannel(IRCMessage& msg, std::string channelName,
+                      std::string key);
+  void addClientToNewChannel(IRCMessage& msg, std::string channelName,
+                             std::string key);
   void sendResponceToFrom(IRCMessage& msg, std::string channelName);
   void sendResponseToChannel(IRCMessage& msg, std::string channelName);
 
+  bool join0(IRCMessage& msg);
 };
 
 #endif  // __COMMAND_JOIN_HPP__

--- a/src/IRCServer.cpp
+++ b/src/IRCServer.cpp
@@ -155,6 +155,10 @@ const std::string& IRCServer::getServerName() const {
   return server_name_;
 }
 
+RequestHandler& IRCServer::getRequestHandler() {
+  return request_handler_;
+}
+
 // Setters
 bool IRCServer::addClient(Client* client) {
   if (clients_.find(client->getFd()) !=


### PR DESCRIPTION
[RFC2812] JOIN 0 #75

RFC2812にあるJOIN 0を実装しました。
内部的にはPARTメッセージを作成して、
handleCommandを読んでいます。
(ngircdもそう動いているように見えます。)

IRCServerクラスに```getRequestHandler()```メソッドを追加しましたが、
handleCommandがserverを変更するため、constは付けていません。
```
  RequestHandler& getRequestHandler(); // こちらで実装
  const RequestHandler& getRequestHandler() const; // プライベートのserver_を変更するため、こう書けない
```
