### PR TITLE
クライアント切断時、チャンネル削除

### DIFF
--- a/include/IRCServer.hpp
+++ b/include/IRCServer.hpp
@@ -21,9 +21,7 @@ class IRCServer {
   std::map<int, Socket*> listenSockets_;  // ソケットFD→listeningソケット
   std::map<int, Client*> clients_;        // ソケットFD→クライアント
   std::map<std::string, Channel*>
-      channels_;  // チャンネル名→チャンネルオブジェクト
-  // UserManager userManager_;
-  // ChannelManager channelManager_;
+      channels_;                  // チャンネル名→チャンネルオブジェクト
   std::set<Client*> send_queue_;  // メッセージ送信待ちのクライアント
   RequestHandler request_handler_;
   std::string server_name_;
@@ -33,7 +31,6 @@ class IRCServer {
   void sendResponses();
   void handleClientMessage(int clientFd);
   void resendClientMessage(int clientFd);
-  void disconnectClient(Client* client);
   void startListen();  // ソケットをバインドしてリッスン状態にする
 
   static const int kMaxBacklog = 100;
@@ -70,10 +67,7 @@ class IRCServer {
   // Member functions
   void run();  // メインループ。接続受付、読み書き処理
   bool isNickTaken(const std::string nick) const;
-  // void acceptConnection();
-  // void receiveMessage(Client* client);
-  // void sendMessage(Client* client, const std::string& message);
-  // void disconnectClient(Client* client);
+  void disconnectClient(Client* client);
 };
 
 #endif  // __IRC_SERVER_HPP__

--- a/test/unit/src/IRCServer.cpp
+++ b/test/unit/src/IRCServer.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include "TestDataGenerator.hpp"
+
 TEST(IRCServerTest, valid_construnctor) {
   {
     const char* port = "6667";
@@ -86,4 +88,27 @@ TEST(IRCServerTest, invalid_password) {
       EXPECT_STREQ(e.what(), "invalid password");
     }
   }
+}
+
+TEST(IRCServerTest, disconnect) {
+  IRCServer server("6677", "pass123");
+  std::map<int, Client*> clients;
+  RequestHandler requestHandler(&server);
+  TestDataGenerator::makeUserData(server, clients, requestHandler);
+
+  // クライアントを切断
+  server.disconnectClient(clients[10]);
+  server.disconnectClient(clients[11]);
+  server.disconnectClient(clients[12]);
+
+  // クライアントが削除されている
+  EXPECT_EQ(server.getClients().find(10), server.getClients().end());
+  EXPECT_EQ(server.getClients().find(11), server.getClients().end());
+  EXPECT_EQ(server.getClients().find(12), server.getClients().end());
+
+  // 誰もいなくなったチャンネルが削除されている
+  EXPECT_TRUE(server.getChannel("#ch1") != NULL);
+  EXPECT_TRUE(server.getChannel("#ch2") == NULL);
+  EXPECT_TRUE(server.getChannel("#ch3") == NULL);
+  EXPECT_TRUE(server.getChannel("#ch4") != NULL);
 }


### PR DESCRIPTION
切断によりチャンネルから全員抜けた場合、チャンネル削除されない #79

クライアントが切断されて、チャンネルに誰もいなくなった時に、
チャンネルを削除するように対応しました。